### PR TITLE
WIP: Implement #6: Port LocalResourceManager logic to Rust

### DIFF
--- a/rust/raylet-rs/src/lib.rs
+++ b/rust/raylet-rs/src/lib.rs
@@ -6,6 +6,7 @@
 use std::os::raw::c_int;
 
 pub mod scheduling_ffi;
+pub mod scheduling;
 
 /// Minimal main entry point for the Rust raylet implementation.
 ///

--- a/rust/raylet-rs/src/scheduling/local_resource_manager.rs
+++ b/rust/raylet-rs/src/scheduling/local_resource_manager.rs
@@ -1,0 +1,411 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::scheduling_ffi::{NodeResources, ResourceRequest};
+
+const UNTRACKED_IDLE_MARKER: i64 = i64::MIN;
+
+type Clock = Arc<dyn Fn() -> i64 + Send + Sync>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkFootprint {
+    NodeWorkers,
+    PullingTaskArguments,
+}
+
+#[derive(Debug, Clone)]
+struct IdleTimeState {
+    current: Option<i64>,
+    saved: Option<i64>,
+}
+
+#[derive(Debug, Clone, Eq)]
+enum WorkArtifact {
+    Footprint(WorkFootprint),
+    Resource(String),
+}
+
+impl PartialEq for WorkArtifact {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Footprint(lhs), Self::Footprint(rhs)) => lhs == rhs,
+            (Self::Resource(lhs), Self::Resource(rhs)) => lhs == rhs,
+            _ => false,
+        }
+    }
+}
+
+impl Hash for WorkArtifact {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Footprint(item) => {
+                0u8.hash(state);
+                item.hash(state);
+            }
+            Self::Resource(resource_name) => {
+                1u8.hash(state);
+                resource_name.hash(state);
+            }
+        }
+    }
+}
+
+pub struct LocalResourceManager {
+    total: HashMap<String, f64>,
+    available: HashMap<String, f64>,
+    idle_time_states: HashMap<WorkArtifact, IdleTimeState>,
+    clock: Clock,
+}
+
+impl LocalResourceManager {
+    pub fn new(node_resources: NodeResources) -> Self {
+        Self::new_with_clock(node_resources, Arc::new(now_ms))
+    }
+
+    pub fn new_with_clock(node_resources: NodeResources, clock: Clock) -> Self {
+        let now = clock();
+        let mut idle_time_states = HashMap::with_capacity(node_resources.total.len());
+        for resource_name in node_resources.total.keys() {
+            idle_time_states.insert(
+                WorkArtifact::Resource(resource_name.clone()),
+                IdleTimeState {
+                    current: Some(now),
+                    saved: None,
+                },
+            );
+        }
+
+        Self {
+            total: node_resources.total,
+            available: node_resources.available,
+            idle_time_states,
+            clock,
+        }
+    }
+
+    pub fn get_available(&self, resource_name: &str) -> Option<f64> {
+        self.available.get(resource_name).copied()
+    }
+
+    pub fn is_available_resource_empty(&self, resource_name: &str) -> bool {
+        self.get_available(resource_name).unwrap_or_default() <= 0.0
+    }
+
+    pub fn allocate(&mut self, request: &ResourceRequest) -> bool {
+        for (resource_name, required) in &request.resources {
+            let available = self.available.get(resource_name).copied().unwrap_or_default();
+            if available + f64::EPSILON < *required {
+                return false;
+            }
+        }
+
+        for (resource_name, required) in &request.resources {
+            if *required <= 0.0 {
+                continue;
+            }
+            if let Some(available) = self.available.get_mut(resource_name) {
+                *available -= *required;
+                self.set_resource_non_idle(resource_name);
+            }
+        }
+
+        true
+    }
+
+    pub fn release(&mut self, released: &HashMap<String, f64>) {
+        for (resource_name, amount) in released {
+            if *amount <= 0.0 {
+                continue;
+            }
+            let Some(total) = self.total.get(resource_name).copied() else {
+                continue;
+            };
+            let Some(available) = self.available.get_mut(resource_name) else {
+                continue;
+            };
+            *available = (*available + *amount).min(total);
+            if (*available - total).abs() <= f64::EPSILON {
+                self.set_resource_idle(resource_name);
+            }
+        }
+    }
+
+    pub fn add_resource_instances(&mut self, resource_name: &str, amount: f64) {
+        if amount <= 0.0 {
+            return;
+        }
+        let Some(total) = self.total.get(resource_name).copied() else {
+            return;
+        };
+        let Some(available) = self.available.get_mut(resource_name) else {
+            return;
+        };
+        *available = (*available + amount).min(total);
+        if (*available - total).abs() <= f64::EPSILON {
+            self.set_resource_idle(resource_name);
+        }
+    }
+
+    pub fn subtract_resource_instances(
+        &mut self,
+        resource_name: &str,
+        amount: f64,
+        allow_going_negative: bool,
+    ) -> f64 {
+        if amount <= 0.0 {
+            return 0.0;
+        }
+
+        let available = self.available.entry(resource_name.to_string()).or_insert(0.0);
+        let underflow = if allow_going_negative {
+            0.0
+        } else {
+            (amount - *available).max(0.0)
+        };
+
+        *available -= amount;
+        if !allow_going_negative {
+            *available = (*available).max(0.0);
+        }
+
+        self.set_resource_non_idle(resource_name);
+        underflow
+    }
+
+    pub fn mark_footprint_as_busy(&mut self, item: WorkFootprint) {
+        if let Some(prev) = self.idle_time_states.get(&WorkArtifact::Footprint(item)) {
+            if prev.current.is_none() {
+                return;
+            }
+        }
+
+        self.idle_time_states.insert(
+            WorkArtifact::Footprint(item),
+            IdleTimeState {
+                current: None,
+                saved: None,
+            },
+        );
+
+        for (artifact, idle_state) in &mut self.idle_time_states {
+            if matches!(artifact, WorkArtifact::Footprint(_)) {
+                idle_state.saved = None;
+            }
+        }
+    }
+
+    pub fn maybe_mark_footprint_as_busy(&mut self, item: WorkFootprint) {
+        let key = WorkArtifact::Footprint(item);
+        if let Some(state) = self.idle_time_states.get(&key) {
+            if state.current.is_none() {
+                return;
+            }
+        }
+
+        if let Some(state) = self.idle_time_states.get_mut(&key) {
+            state.saved = state.current;
+            state.current = None;
+            return;
+        }
+
+        self.idle_time_states.insert(
+            key,
+            IdleTimeState {
+                current: None,
+                saved: Some(UNTRACKED_IDLE_MARKER),
+            },
+        );
+    }
+
+    pub fn mark_footprint_as_idle(&mut self, item: WorkFootprint) {
+        let key = WorkArtifact::Footprint(item);
+        if let Some(prev) = self.idle_time_states.get(&key) {
+            if prev.current.is_some() && prev.saved.is_none() {
+                return;
+            }
+        }
+
+        let saved_idle_time = self.idle_time_states.get(&key).and_then(|state| state.saved);
+        if saved_idle_time == Some(UNTRACKED_IDLE_MARKER) {
+            self.idle_time_states.remove(&key);
+            return;
+        }
+
+        if let Some(saved) = saved_idle_time {
+            if let Some(state) = self.idle_time_states.get_mut(&key) {
+                state.current = Some(saved);
+                state.saved = None;
+            }
+            return;
+        }
+
+        let now = (self.clock)();
+        self.idle_time_states
+            .entry(key)
+            .and_modify(|state| {
+                state.current = Some(now);
+                state.saved = None;
+            })
+            .or_insert(IdleTimeState {
+                current: Some(now),
+                saved: None,
+            });
+    }
+
+    pub fn get_resource_idle_time(&self) -> Option<i64> {
+        let mut all_idle_time = i64::MIN;
+        for idle_state in self.idle_time_states.values() {
+            let current = idle_state.current?;
+            all_idle_time = all_idle_time.max(current);
+        }
+        Some(all_idle_time)
+    }
+
+    pub fn is_local_node_idle(&self) -> bool {
+        self.get_resource_idle_time().is_some()
+    }
+
+    fn set_resource_non_idle(&mut self, resource_name: &str) {
+        let state = self
+            .idle_time_states
+            .entry(WorkArtifact::Resource(resource_name.to_string()))
+            .or_insert(IdleTimeState {
+                current: Some((self.clock)()),
+                saved: None,
+            });
+        state.current = None;
+    }
+
+    fn set_resource_idle(&mut self, resource_name: &str) {
+        let state = self
+            .idle_time_states
+            .entry(WorkArtifact::Resource(resource_name.to_string()))
+            .or_insert(IdleTimeState {
+                current: Some((self.clock)()),
+                saved: None,
+            });
+        state.current = Some((self.clock)());
+    }
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    use super::*;
+    use crate::scheduling_ffi::{LabelSelector, ResourceRequest};
+
+    fn fake_manager() -> (LocalResourceManager, Arc<AtomicI64>) {
+        let now = Arc::new(AtomicI64::new(1000));
+        let fake_clock = {
+            let now = now.clone();
+            Arc::new(move || now.load(Ordering::Relaxed))
+        };
+        let mut total = HashMap::new();
+        total.insert("CPU".to_string(), 2.0);
+        total.insert("GPU".to_string(), 1.0);
+        let mut available = HashMap::new();
+        available.insert("CPU".to_string(), 2.0);
+        available.insert("GPU".to_string(), 1.0);
+
+        (
+            LocalResourceManager::new_with_clock(
+                NodeResources {
+                    total,
+                    available,
+                    load: HashMap::new(),
+                    normal_task_resources: HashMap::new(),
+                    labels: HashMap::new(),
+                    idle_resource_duration_ms: 0,
+                    is_draining: false,
+                    draining_deadline_timestamp_ms: -1,
+                    last_resource_update_ms: 0,
+                    latest_resources_normal_task_timestamp: 0,
+                    object_pulls_queued: false,
+                },
+                fake_clock,
+            ),
+            now,
+        )
+    }
+
+    #[test]
+    fn allocate_release_roundtrip() {
+        let (mut manager, _) = fake_manager();
+
+        let mut resources = HashMap::new();
+        resources.insert("CPU".to_string(), 1.0);
+        let request = ResourceRequest {
+            resources,
+            requires_object_store_memory: false,
+            label_selector: LabelSelector {
+                constraints: Vec::new(),
+            },
+        };
+
+        assert!(manager.allocate(&request));
+        assert_eq!(manager.get_available("CPU"), Some(1.0));
+        assert!(!manager.is_local_node_idle());
+
+        let mut released = HashMap::new();
+        released.insert("CPU".to_string(), 1.0);
+        manager.release(&released);
+        assert_eq!(manager.get_available("CPU"), Some(2.0));
+        assert!(manager.is_local_node_idle());
+    }
+
+    #[test]
+    fn subtract_resource_instances_returns_underflow() {
+        let (mut manager, _) = fake_manager();
+        let underflow = manager.subtract_resource_instances("CPU", 3.0, false);
+        assert_eq!(underflow, 1.0);
+        assert_eq!(manager.get_available("CPU"), Some(0.0));
+    }
+
+    #[test]
+    fn maybe_mark_footprint_as_busy_restores_idle_time() {
+        let (mut manager, now) = fake_manager();
+        let initial = manager.get_resource_idle_time().expect("initial idle time");
+
+        now.store(1050, Ordering::Relaxed);
+        manager.maybe_mark_footprint_as_busy(WorkFootprint::PullingTaskArguments);
+        assert!(!manager.is_local_node_idle());
+
+        now.store(1100, Ordering::Relaxed);
+        manager.mark_footprint_as_idle(WorkFootprint::PullingTaskArguments);
+        assert_eq!(manager.get_resource_idle_time(), Some(initial));
+    }
+
+    #[test]
+    fn mark_footprint_busy_resets_idle_time() {
+        let (mut manager, now) = fake_manager();
+
+        now.store(1050, Ordering::Relaxed);
+        manager.mark_footprint_as_busy(WorkFootprint::NodeWorkers);
+        assert!(!manager.is_local_node_idle());
+
+        now.store(1100, Ordering::Relaxed);
+        manager.mark_footprint_as_idle(WorkFootprint::NodeWorkers);
+        assert_eq!(manager.get_resource_idle_time(), Some(1100));
+    }
+
+    #[test]
+    fn repeated_mark_footprint_idle_is_noop() {
+        let (mut manager, now) = fake_manager();
+        manager.mark_footprint_as_idle(WorkFootprint::PullingTaskArguments);
+        let first_idle = manager.get_resource_idle_time().expect("idle time");
+
+        now.store(1500, Ordering::Relaxed);
+        manager.mark_footprint_as_idle(WorkFootprint::PullingTaskArguments);
+        assert_eq!(manager.get_resource_idle_time(), Some(first_idle));
+    }
+}

--- a/rust/raylet-rs/src/scheduling/mod.rs
+++ b/rust/raylet-rs/src/scheduling/mod.rs
@@ -1,0 +1,1 @@
+pub mod local_resource_manager;

--- a/rust/raylet-rs/src/scheduling_ffi.rs
+++ b/rust/raylet-rs/src/scheduling_ffi.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::os::raw::c_char;
+use std::ptr;
 use std::slice;
 use std::str;
+
+use crate::scheduling::local_resource_manager::{LocalResourceManager, WorkFootprint};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FfiError {
@@ -159,6 +162,18 @@ pub struct RayletSchedulingDecision {
     pub selected_node_id: i64,
     pub is_feasible: u8,
     pub is_spillback: u8,
+}
+
+#[repr(C)]
+pub struct RayletLocalResourceManagerHandle {
+    manager: LocalResourceManager,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletWorkFootprint {
+    NodeWorkers = 1,
+    PullingTaskArguments = 2,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -354,6 +369,15 @@ impl RayletSchedulingDecision {
     }
 }
 
+impl RayletWorkFootprint {
+    fn to_rust(self) -> WorkFootprint {
+        match self {
+            Self::NodeWorkers => WorkFootprint::NodeWorkers,
+            Self::PullingTaskArguments => WorkFootprint::PullingTaskArguments,
+        }
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn raylet_rs_scheduler_roundtrip(
     request: *const RayletSchedulingRequest,
@@ -373,6 +397,207 @@ pub extern "C" fn raylet_rs_scheduler_roundtrip(
         *decision_out = decision;
     }
     1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_create(
+    node_resources: *const RayletNodeResources,
+) -> *mut RayletLocalResourceManagerHandle {
+    if node_resources.is_null() {
+        return ptr::null_mut();
+    }
+
+    let node_resources = unsafe { &*node_resources };
+    let node_resources = match unsafe { node_resources.to_rust() } {
+        Ok(resources) => resources,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    let handle = RayletLocalResourceManagerHandle {
+        manager: LocalResourceManager::new(node_resources),
+    };
+
+    Box::into_raw(Box::new(handle))
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_destroy(
+    handle: *mut RayletLocalResourceManagerHandle,
+) {
+    if handle.is_null() {
+        return;
+    }
+
+    unsafe {
+        drop(Box::from_raw(handle));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_allocate(
+    handle: *mut RayletLocalResourceManagerHandle,
+    request: *const RayletResourceRequest,
+) -> u8 {
+    if handle.is_null() || request.is_null() {
+        return 0;
+    }
+
+    let handle = unsafe { &mut *handle };
+    let request = unsafe { &*request };
+    let request = match unsafe { request.to_rust() } {
+        Ok(request) => request,
+        Err(_) => return 0,
+    };
+
+    handle.manager.allocate(&request) as u8
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_release(
+    handle: *mut RayletLocalResourceManagerHandle,
+    resources: *const RayletResourceArray,
+) -> u8 {
+    if handle.is_null() || resources.is_null() {
+        return 0;
+    }
+
+    let handle = unsafe { &mut *handle };
+    let resources = unsafe { &*resources };
+    let resources = match unsafe { resources.to_map() } {
+        Ok(resources) => resources,
+        Err(_) => return 0,
+    };
+
+    handle.manager.release(&resources);
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_get_available(
+    handle: *const RayletLocalResourceManagerHandle,
+    resource_name: RayletStr,
+    available_out: *mut f64,
+) -> u8 {
+    if handle.is_null() || available_out.is_null() {
+        return 0;
+    }
+
+    let resource_name = match unsafe { resource_name.as_str() } {
+        Ok(name) => name,
+        Err(_) => return 0,
+    };
+
+    let handle = unsafe { &*handle };
+    let Some(available) = handle.manager.get_available(resource_name) else {
+        return 0;
+    };
+
+    unsafe {
+        *available_out = available;
+    }
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_add_resource_instances(
+    handle: *mut RayletLocalResourceManagerHandle,
+    resource_name: RayletStr,
+    amount: f64,
+) -> u8 {
+    if handle.is_null() {
+        return 0;
+    }
+
+    let resource_name = match unsafe { resource_name.as_str() } {
+        Ok(name) => name,
+        Err(_) => return 0,
+    };
+
+    let handle = unsafe { &mut *handle };
+    handle.manager.add_resource_instances(resource_name, amount);
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_subtract_resource_instances(
+    handle: *mut RayletLocalResourceManagerHandle,
+    resource_name: RayletStr,
+    amount: f64,
+    allow_going_negative: u8,
+    underflow_out: *mut f64,
+) -> u8 {
+    if handle.is_null() || underflow_out.is_null() {
+        return 0;
+    }
+
+    let resource_name = match unsafe { resource_name.as_str() } {
+        Ok(name) => name,
+        Err(_) => return 0,
+    };
+
+    let handle = unsafe { &mut *handle };
+    let underflow = handle.manager.subtract_resource_instances(
+        resource_name,
+        amount,
+        allow_going_negative != 0,
+    );
+    unsafe {
+        *underflow_out = underflow;
+    }
+
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_mark_footprint_busy(
+    handle: *mut RayletLocalResourceManagerHandle,
+    footprint: RayletWorkFootprint,
+) -> u8 {
+    if handle.is_null() {
+        return 0;
+    }
+    let handle = unsafe { &mut *handle };
+    handle.manager.mark_footprint_as_busy(footprint.to_rust());
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_maybe_mark_footprint_busy(
+    handle: *mut RayletLocalResourceManagerHandle,
+    footprint: RayletWorkFootprint,
+) -> u8 {
+    if handle.is_null() {
+        return 0;
+    }
+    let handle = unsafe { &mut *handle };
+    handle
+        .manager
+        .maybe_mark_footprint_as_busy(footprint.to_rust());
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_mark_footprint_idle(
+    handle: *mut RayletLocalResourceManagerHandle,
+    footprint: RayletWorkFootprint,
+) -> u8 {
+    if handle.is_null() {
+        return 0;
+    }
+    let handle = unsafe { &mut *handle };
+    handle.manager.mark_footprint_as_idle(footprint.to_rust());
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn raylet_rs_local_resource_manager_is_node_idle(
+    handle: *const RayletLocalResourceManagerHandle,
+) -> u8 {
+    if handle.is_null() {
+        return 0;
+    }
+    let handle = unsafe { &*handle };
+    handle.manager.is_local_node_idle() as u8
 }
 
 #[cfg(test)]
@@ -475,5 +700,90 @@ mod tests {
         assert_eq!(size_of::<RayletResourceRequest>(), 40);
         assert_eq!(size_of::<RayletSchedulingRequest>(), 56);
         assert_eq!(size_of::<RayletSchedulingDecision>(), 24);
+    }
+
+    #[test]
+    fn local_resource_manager_ffi_allocate_release() {
+        let cpu = RayletStr {
+            data: b"CPU".as_ptr() as *const c_char,
+            len: 3,
+        };
+        let entries = [RayletResourceEntry {
+            name: cpu,
+            value: 2.0,
+        }];
+        let resources = RayletResourceArray {
+            entries: entries.as_ptr(),
+            len: entries.len(),
+        };
+        let node_resources = RayletNodeResources {
+            total: resources,
+            available: resources,
+            load: RayletResourceArray {
+                entries: ptr::null(),
+                len: 0,
+            },
+            normal_task_resources: RayletResourceArray {
+                entries: ptr::null(),
+                len: 0,
+            },
+            labels: RayletLabelArray {
+                entries: ptr::null(),
+                len: 0,
+            },
+            idle_resource_duration_ms: 0,
+            is_draining: 0,
+            draining_deadline_timestamp_ms: -1,
+            last_resource_update_ms: 0,
+            latest_resources_normal_task_timestamp: 0,
+            object_pulls_queued: 0,
+        };
+
+        let handle = raylet_rs_local_resource_manager_create(&node_resources as *const _);
+        assert!(!handle.is_null());
+
+        let request_entries = [RayletResourceEntry {
+            name: cpu,
+            value: 1.0,
+        }];
+        let request = RayletResourceRequest {
+            resources: RayletResourceArray {
+                entries: request_entries.as_ptr(),
+                len: request_entries.len(),
+            },
+            requires_object_store_memory: 0,
+            label_selector: RayletLabelSelector {
+                constraints: ptr::null(),
+                len: 0,
+            },
+        };
+        assert_eq!(raylet_rs_local_resource_manager_allocate(handle, &request), 1);
+
+        let mut available = -1.0;
+        assert_eq!(
+            raylet_rs_local_resource_manager_get_available(handle, cpu, &mut available),
+            1
+        );
+        assert_eq!(available, 1.0);
+
+        let release_entries = [RayletResourceEntry {
+            name: cpu,
+            value: 1.0,
+        }];
+        let release_resources = RayletResourceArray {
+            entries: release_entries.as_ptr(),
+            len: release_entries.len(),
+        };
+        assert_eq!(
+            raylet_rs_local_resource_manager_release(handle, &release_resources),
+            1
+        );
+        assert_eq!(
+            raylet_rs_local_resource_manager_get_available(handle, cpu, &mut available),
+            1
+        );
+        assert_eq!(available, 2.0);
+
+        raylet_rs_local_resource_manager_destroy(handle);
     }
 }

--- a/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
+++ b/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
@@ -95,6 +95,13 @@ struct RayletSchedulingDecision {
   uint8_t is_spillback;
 };
 
+struct RayletLocalResourceManagerHandle;
+
+enum class RayletWorkFootprint : uint8_t {
+  kNodeWorkers = 1,
+  kPullingTaskArguments = 2,
+};
+
 inline RayletStr RayletStrFromRaw(const char *data, size_t len) {
   return RayletStr{data, len};
 }
@@ -121,6 +128,44 @@ inline RayletStrArray RayletStrArrayFromRaw(const RayletStr *entries, size_t len
 extern "C" {
 uint8_t raylet_rs_scheduler_roundtrip(const RayletSchedulingRequest *request,
                                       RayletSchedulingDecision *decision_out);
+
+RayletLocalResourceManagerHandle *raylet_rs_local_resource_manager_create(
+    const RayletNodeResources *node_resources);
+
+void raylet_rs_local_resource_manager_destroy(RayletLocalResourceManagerHandle *handle);
+
+uint8_t raylet_rs_local_resource_manager_allocate(
+    RayletLocalResourceManagerHandle *handle, const RayletResourceRequest *request);
+
+uint8_t raylet_rs_local_resource_manager_release(RayletLocalResourceManagerHandle *handle,
+                                                 const RayletResourceArray *resources);
+
+uint8_t raylet_rs_local_resource_manager_get_available(
+    const RayletLocalResourceManagerHandle *handle,
+    RayletStr resource_name,
+    double *available_out);
+
+uint8_t raylet_rs_local_resource_manager_add_resource_instances(
+    RayletLocalResourceManagerHandle *handle, RayletStr resource_name, double amount);
+
+uint8_t raylet_rs_local_resource_manager_subtract_resource_instances(
+    RayletLocalResourceManagerHandle *handle,
+    RayletStr resource_name,
+    double amount,
+    uint8_t allow_going_negative,
+    double *underflow_out);
+
+uint8_t raylet_rs_local_resource_manager_mark_footprint_busy(
+    RayletLocalResourceManagerHandle *handle, RayletWorkFootprint footprint);
+
+uint8_t raylet_rs_local_resource_manager_maybe_mark_footprint_busy(
+    RayletLocalResourceManagerHandle *handle, RayletWorkFootprint footprint);
+
+uint8_t raylet_rs_local_resource_manager_mark_footprint_idle(
+    RayletLocalResourceManagerHandle *handle, RayletWorkFootprint footprint);
+
+uint8_t raylet_rs_local_resource_manager_is_node_idle(
+    const RayletLocalResourceManagerHandle *handle);
 }
 
 }  // namespace ray::raylet::ffi


### PR DESCRIPTION
Closes #6

## Changes
- `rust/raylet-rs/src/scheduling/local_resource_manager.rs`: added a Rust `LocalResourceManager` model with resource accounting and idle-state/footprint behavior mirroring core C++ semantics.
- `rust/raylet-rs/src/scheduling_ffi.rs`: added C ABI handle lifecycle and operation functions (`create/destroy/allocate/release/add/subtract/get_available` plus footprint busy/idle operations) backed by the Rust manager.
- `src/ray/raylet/scheduling/ffi/scheduling_ffi.h`: declared the new LocalResourceManager FFI handle, footprint enum, and extern function surface for C++ callers.
- `rust/raylet-rs/src/scheduling/mod.rs` and `rust/raylet-rs/src/lib.rs`: wired the new scheduling module into the crate.

## Status
- [x] Mirror the current `LocalResourceManager` state machine and APIs in a new Rust module.
- [x] Provide safe Rust wrappers plus an `extern "C"` surface for resource accounting/update/apply operations.
- [x] Add Rust unit tests covering key LocalResourceManager edge cases.
- [ ] Update the C++ raylet to call the Rust FFI instead of the C++ `LocalResourceManager` and keep Bazel build passing. NOT DONE: the current Bazel graph in this branch still builds the C++ `LocalResourceManager`; no Rust cdylib/cc_import wiring exists yet to link these new symbols into raylet.
- [ ] Ensure existing scheduler tests still pass (or are updated to exercise the Rust path). PARTIAL: Rust unit tests pass and `scheduling_ffi_layout_test` passes; full C++ scheduler test target currently fails to build due unrelated upstream toolchain warning promoted to error.

## Validation
- `cargo test -- --test-threads=1` (pass)
- `bazel test //src/ray/raylet/scheduling/tests:scheduling_ffi_layout_test` (pass)
- `bazel test //src/ray/raylet/scheduling/tests:local_resource_manager_test` (fails to build due upstream Abseil deprecated builtin warning under `-Werror` in `//src/ray/util:logging`)