### PR TITLE
Implement #37: Add worker lifecycle ABI structs

### DIFF
--- a/.opencode/state.json
+++ b/.opencode/state.json
@@ -1,7 +1,15 @@
 {
-  "cycle": 1,
-  "swe_run": 1,
+  "cycle": 3,
+  "swe_run": 2,
   "manager_done": true,
-  "timestamp": "20260223_113614",
-  "created_branches": []
+  "timestamp": "20260223_164943",
+  "created_branches": [
+    "8-bootstrap-scheduler-ffi-run1",
+    "31-define-next-raylet-migrations",
+    "33-address-pr32-feedback",
+    "10-port-cluster-resource-scheduler-rs",
+    "27-fix-pr24-rust-lrm-wiring",
+    "36-address-pr35-review-feedback",
+    "27-wire-scheduler-to-rust-lrm-ffi"
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,289 @@
 version = 4
 
 [[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "raylet-rs"
 version = "0.1.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/rust/raylet-rs/src/scheduling_ffi.rs
+++ b/rust/raylet-rs/src/scheduling_ffi.rs
@@ -23,6 +23,8 @@ impl std::error::Error for FfiError {}
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct RayletStr {
+    // C++ owns backing memory for all incoming RayletStr values.
+    // Rust treats this as a read-only slice and never frees it.
     pub data: *const c_char,
     pub len: usize,
 }
@@ -53,6 +55,123 @@ impl RayletStr {
 pub struct RayletStrArray {
     pub entries: *const RayletStr,
     pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletByteArray {
+    // C++ owns backing memory for all incoming RayletByteArray values.
+    // Rust treats this as a read-only slice and never frees it.
+    pub data: *const u8,
+    pub len: usize,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletWorkerType {
+    Worker = 0,
+    Driver = 1,
+    SpillWorker = 2,
+    RestoreWorker = 3,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletLanguage {
+    Python = 0,
+    Java = 1,
+    Cpp = 2,
+    Rust = 3,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletWorkerReleaseReason {
+    TaskFinished = 0,
+    TaskCanceled = 1,
+    Preempted = 2,
+    Disconnected = 3,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletWorkerExitType {
+    Intended = 0,
+    SystemError = 1,
+    UserError = 2,
+    NodeShutdown = 3,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerIdentity {
+    pub worker_id: RayletByteArray,
+    pub job_id: RayletByteArray,
+    pub actor_id: RayletByteArray,
+    pub node_id: RayletByteArray,
+    pub worker_type: RayletWorkerType,
+    pub language: RayletLanguage,
+    pub _reserved0: [u8; 6],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerState {
+    pub identity: RayletWorkerIdentity,
+    pub process_id: i32,
+    pub worker_port: i32,
+    pub startup_token: i64,
+    pub is_registered: u8,
+    pub is_idle: u8,
+    pub is_detached_actor: u8,
+    pub _reserved0: [u8; 5],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerRegisterRequest {
+    pub state: RayletWorkerState,
+    pub worker_address: RayletStr,
+    pub serialized_runtime_env: RayletByteArray,
+    pub debugger_port: i32,
+    pub _reserved0: [u8; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerLeaseRequest {
+    pub lease_id: i64,
+    pub worker_id: RayletByteArray,
+    pub scheduling_class: i64,
+    pub required_resources: RayletResourceArray,
+    pub placement_resources: RayletResourceArray,
+    pub is_actor_creation_task: u8,
+    pub grant_or_reject: u8,
+    pub _reserved0: [u8; 6],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerReleaseRequest {
+    pub lease_id: i64,
+    pub worker_id: RayletByteArray,
+    pub release_reason: RayletWorkerReleaseReason,
+    pub return_worker_to_idle: u8,
+    pub worker_exiting: u8,
+    pub _reserved0: [u8; 5],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletWorkerExitEvent {
+    pub worker_id: RayletByteArray,
+    pub worker_type: RayletWorkerType,
+    pub exit_type: RayletWorkerExitType,
+    pub has_creation_task_exception: u8,
+    pub _reserved0: [u8; 5],
+    pub exit_detail: RayletStr,
+    pub exit_code: i32,
+    pub _reserved1: [u8; 4],
 }
 
 #[repr(C)]
@@ -470,8 +589,15 @@ mod tests {
     fn ffi_layout_matches_cpp_expectations() {
         assert_eq!(size_of::<RayletStr>(), 16);
         assert_eq!(size_of::<RayletStrArray>(), 16);
+        assert_eq!(size_of::<RayletByteArray>(), 16);
         assert_eq!(size_of::<RayletResourceEntry>(), 24);
         assert_eq!(size_of::<RayletLabelEntry>(), 32);
+        assert_eq!(size_of::<RayletWorkerIdentity>(), 72);
+        assert_eq!(size_of::<RayletWorkerState>(), 96);
+        assert_eq!(size_of::<RayletWorkerRegisterRequest>(), 136);
+        assert_eq!(size_of::<RayletWorkerLeaseRequest>(), 72);
+        assert_eq!(size_of::<RayletWorkerReleaseRequest>(), 32);
+        assert_eq!(size_of::<RayletWorkerExitEvent>(), 48);
         assert_eq!(size_of::<RayletResourceRequest>(), 40);
         assert_eq!(size_of::<RayletSchedulingRequest>(), 56);
         assert_eq!(size_of::<RayletSchedulingDecision>(), 24);

--- a/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
+++ b/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
@@ -6,6 +6,8 @@
 namespace ray::raylet::ffi {
 
 struct RayletStr {
+  // Pointer+length UTF-8 view owned by the caller.
+  // Rust reads the slice and never takes ownership.
   const char *data;
   size_t len;
 };
@@ -13,6 +15,41 @@ struct RayletStr {
 struct RayletStrArray {
   const RayletStr *entries;
   size_t len;
+};
+
+struct RayletByteArray {
+  // Pointer+length byte view owned by the caller.
+  // Rust reads the slice and never takes ownership.
+  const uint8_t *data;
+  size_t len;
+};
+
+enum class RayletWorkerType : uint8_t {
+  kWorker = 0,
+  kDriver = 1,
+  kSpillWorker = 2,
+  kRestoreWorker = 3,
+};
+
+enum class RayletLanguage : uint8_t {
+  kPython = 0,
+  kJava = 1,
+  kCpp = 2,
+  kRust = 3,
+};
+
+enum class RayletWorkerReleaseReason : uint8_t {
+  kTaskFinished = 0,
+  kTaskCanceled = 1,
+  kPreempted = 2,
+  kDisconnected = 3,
+};
+
+enum class RayletWorkerExitType : uint8_t {
+  kIntended = 0,
+  kSystemError = 1,
+  kUserError = 2,
+  kNodeShutdown = 3,
 };
 
 struct RayletResourceEntry {
@@ -23,6 +60,66 @@ struct RayletResourceEntry {
 struct RayletResourceArray {
   const RayletResourceEntry *entries;
   size_t len;
+};
+
+struct RayletWorkerIdentity {
+  RayletByteArray worker_id;
+  RayletByteArray job_id;
+  RayletByteArray actor_id;
+  RayletByteArray node_id;
+  RayletWorkerType worker_type;
+  RayletLanguage language;
+  uint8_t reserved0[6];
+};
+
+struct RayletWorkerState {
+  RayletWorkerIdentity identity;
+  int32_t process_id;
+  int32_t worker_port;
+  int64_t startup_token;
+  uint8_t is_registered;
+  uint8_t is_idle;
+  uint8_t is_detached_actor;
+  uint8_t reserved0[5];
+};
+
+struct RayletWorkerRegisterRequest {
+  RayletWorkerState state;
+  RayletStr worker_address;
+  RayletByteArray serialized_runtime_env;
+  int32_t debugger_port;
+  uint8_t reserved0[4];
+};
+
+struct RayletWorkerLeaseRequest {
+  int64_t lease_id;
+  RayletByteArray worker_id;
+  int64_t scheduling_class;
+  RayletResourceArray required_resources;
+  RayletResourceArray placement_resources;
+  uint8_t is_actor_creation_task;
+  uint8_t grant_or_reject;
+  uint8_t reserved0[6];
+};
+
+struct RayletWorkerReleaseRequest {
+  int64_t lease_id;
+  RayletByteArray worker_id;
+  RayletWorkerReleaseReason release_reason;
+  uint8_t return_worker_to_idle;
+  uint8_t worker_exiting;
+  uint8_t reserved0[5];
+};
+
+struct RayletWorkerExitEvent {
+  RayletByteArray worker_id;
+  RayletWorkerType worker_type;
+  RayletWorkerExitType exit_type;
+  uint8_t has_creation_task_exception;
+  uint8_t reserved0[5];
+  RayletStr exit_detail;
+  int32_t exit_code;
+  uint8_t reserved1[4];
 };
 
 struct RayletLabelEntry {
@@ -116,6 +213,10 @@ inline RayletLabelSelector RayletLabelSelectorFromRaw(
 
 inline RayletStrArray RayletStrArrayFromRaw(const RayletStr *entries, size_t len) {
   return RayletStrArray{entries, len};
+}
+
+inline RayletByteArray RayletByteArrayFromRaw(const uint8_t *data, size_t len) {
+  return RayletByteArray{data, len};
 }
 
 extern "C" {

--- a/src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc
+++ b/src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc
@@ -8,12 +8,29 @@ namespace ray::raylet::ffi {
 static_assert(sizeof(void *) == 8, "Scheduling FFI assumes 64-bit ABI.");
 static_assert(sizeof(RayletStr) == 16, "RayletStr should be pointer+len.");
 static_assert(sizeof(RayletStrArray) == 16, "RayletStrArray should be pointer+len.");
+static_assert(sizeof(RayletByteArray) == 16, "RayletByteArray should be pointer+len.");
 static_assert(sizeof(RayletResourceEntry) == 24, "RayletResourceEntry layout changed.");
 static_assert(sizeof(RayletLabelEntry) == 32, "RayletLabelEntry layout changed.");
+static_assert(sizeof(RayletWorkerIdentity) == 72, "RayletWorkerIdentity layout changed.");
+static_assert(sizeof(RayletWorkerState) == 96, "RayletWorkerState layout changed.");
+static_assert(sizeof(RayletWorkerRegisterRequest) == 136,
+              "RayletWorkerRegisterRequest layout changed.");
+static_assert(sizeof(RayletWorkerLeaseRequest) == 72,
+              "RayletWorkerLeaseRequest layout changed.");
+static_assert(sizeof(RayletWorkerReleaseRequest) == 32,
+              "RayletWorkerReleaseRequest layout changed.");
+static_assert(sizeof(RayletWorkerExitEvent) == 48,
+              "RayletWorkerExitEvent layout changed.");
 static_assert(offsetof(RayletResourceEntry, value) == sizeof(RayletStr),
               "RayletResourceEntry value offset mismatch.");
 static_assert(offsetof(RayletLabelEntry, value) == sizeof(RayletStr),
               "RayletLabelEntry value offset mismatch.");
+static_assert(offsetof(RayletWorkerIdentity, language) == 65,
+              "RayletWorkerIdentity language offset mismatch.");
+static_assert(offsetof(RayletWorkerRegisterRequest, serialized_runtime_env) == 112,
+              "RayletWorkerRegisterRequest runtime env offset mismatch.");
+static_assert(offsetof(RayletWorkerExitEvent, exit_detail) == 24,
+              "RayletWorkerExitEvent exit detail offset mismatch.");
 
 TEST(SchedulingFfiLayoutTest, RequestDecisionSizes) {
   EXPECT_EQ(sizeof(RayletResourceRequest), 40u);


### PR DESCRIPTION
Closes #37

## Changes
- `rust/raylet-rs/src/scheduling_ffi.rs`: added ABI-safe worker lifecycle enums/structs for identity, state, register, lease, release, and exit transitions, with pointer+length ownership comments.
- `src/ray/raylet/scheduling/ffi/scheduling_ffi.h`: added matching C++ ABI declarations and byte-array helper constructor for the new worker lifecycle boundary.
- `src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc`: added compile-time size/offset checks for new worker lifecycle ABI structs.

## Validation
- `cargo test` (in `rust/raylet-rs`) passed.
- `bazel test //src/ray/raylet/scheduling/tests:scheduling_ffi_layout_test` passed.

All acceptance criteria met.