### PR TITLE
Implement #38: Add placement-group FFI ABI structs

### DIFF
--- a/rust/raylet-rs/src/scheduling_ffi.rs
+++ b/rust/raylet-rs/src/scheduling_ffi.rs
@@ -6,6 +6,15 @@ use std::str;
 
 use crate::scheduling::local_resource_manager::{LocalResourceManager, WorkFootprint};
 
+/// Placement-group reservation ABI version.
+///
+/// Versioning and ownership rules for placement-group ABI structs:
+/// - `abi_version` is set by the caller to `RAYLET_PG_ABI_VERSION`.
+/// - Pointer fields are borrowed for the duration of a single FFI call.
+/// - Rust and C++ must not store borrowed pointers after the call returns.
+/// - Fields are append-only and semantic changes require a version bump.
+pub const RAYLET_PG_ABI_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FfiError {
     NullPointer(&'static str),
@@ -162,6 +171,59 @@ pub struct RayletSchedulingDecision {
     pub selected_node_id: i64,
     pub is_feasible: u8,
     pub is_spillback: u8,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletPgCommitReleaseOp {
+    Commit = 1,
+    Release = 2,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RayletPgResultCode {
+    Ok = 0,
+    Infeasible = 1,
+    ResourcesBusy = 2,
+    Invalid = 3,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletPgBundleSpec {
+    pub abi_version: u32,
+    pub reserved: u32,
+    pub placement_group_id_high: i64,
+    pub placement_group_id_low: i64,
+    pub bundle_index: i64,
+    pub required_resources: RayletResourceArray,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletPgBundleAllocation {
+    pub abi_version: u32,
+    pub reserved: u32,
+    pub placement_group_id_high: i64,
+    pub placement_group_id_low: i64,
+    pub bundle_index: i64,
+    pub allocation_epoch: i64,
+    pub allocated_resources: RayletResourceArray,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RayletPgCommitReleaseResult {
+    pub abi_version: u32,
+    pub reserved: u32,
+    pub placement_group_id_high: i64,
+    pub placement_group_id_low: i64,
+    pub bundle_index: i64,
+    pub operation: RayletPgCommitReleaseOp,
+    pub result: RayletPgResultCode,
+    pub reserved_flags: u16,
+    pub reserved_code: u32,
 }
 
 #[repr(C)]
@@ -893,5 +955,8 @@ mod tests {
         assert_eq!(size_of::<RayletResourceRequest>(), 40);
         assert_eq!(size_of::<RayletSchedulingRequest>(), 56);
         assert_eq!(size_of::<RayletSchedulingDecision>(), 24);
+        assert_eq!(size_of::<RayletPgBundleSpec>(), 48);
+        assert_eq!(size_of::<RayletPgBundleAllocation>(), 56);
+        assert_eq!(size_of::<RayletPgCommitReleaseResult>(), 40);
     }
 }

--- a/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
+++ b/src/ray/raylet/scheduling/ffi/scheduling_ffi.h
@@ -5,6 +5,15 @@
 
 namespace ray::raylet::ffi {
 
+// Placement-group reservation ABI version.
+//
+// Versioning and ownership rules for placement-group ABI structs:
+// - `abi_version` must be set to `kRayletPgAbiVersion` by the caller.
+// - Pointer fields are borrowed only for the duration of an FFI call.
+// - Callees must not retain pointers after returning to the caller.
+// - New fields are append-only and require a version bump when semantics change.
+inline constexpr uint32_t kRayletPgAbiVersion = 1;
+
 struct RayletStr {
   const char *data;
   size_t len;
@@ -93,6 +102,51 @@ struct RayletSchedulingDecision {
   int64_t selected_node_id;
   uint8_t is_feasible;
   uint8_t is_spillback;
+};
+
+enum class RayletPgCommitReleaseOp : uint8_t {
+  kCommit = 1,
+  kRelease = 2,
+};
+
+enum class RayletPgResultCode : uint8_t {
+  kOk = 0,
+  kInfeasible = 1,
+  kResourcesBusy = 2,
+  kInvalid = 3,
+};
+
+struct RayletPgBundleSpec {
+  // `required_resources` points to caller-owned memory and is borrow-only.
+  uint32_t abi_version;
+  uint32_t reserved;
+  int64_t placement_group_id_high;
+  int64_t placement_group_id_low;
+  int64_t bundle_index;
+  RayletResourceArray required_resources;
+};
+
+struct RayletPgBundleAllocation {
+  // `allocated_resources` points to caller-owned memory and is borrow-only.
+  uint32_t abi_version;
+  uint32_t reserved;
+  int64_t placement_group_id_high;
+  int64_t placement_group_id_low;
+  int64_t bundle_index;
+  int64_t allocation_epoch;
+  RayletResourceArray allocated_resources;
+};
+
+struct RayletPgCommitReleaseResult {
+  uint32_t abi_version;
+  uint32_t reserved;
+  int64_t placement_group_id_high;
+  int64_t placement_group_id_low;
+  int64_t bundle_index;
+  RayletPgCommitReleaseOp operation;
+  RayletPgResultCode result;
+  uint16_t reserved_flags;
+  uint32_t reserved_code;
 };
 
 struct RayletLocalResourceManagerHandle;

--- a/src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc
+++ b/src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc
@@ -14,11 +14,32 @@ static_assert(offsetof(RayletResourceEntry, value) == sizeof(RayletStr),
               "RayletResourceEntry value offset mismatch.");
 static_assert(offsetof(RayletLabelEntry, value) == sizeof(RayletStr),
               "RayletLabelEntry value offset mismatch.");
+static_assert(sizeof(RayletPgBundleSpec) == 48, "RayletPgBundleSpec layout changed.");
+static_assert(sizeof(RayletPgBundleAllocation) == 56,
+              "RayletPgBundleAllocation layout changed.");
+static_assert(sizeof(RayletPgCommitReleaseResult) == 40,
+              "RayletPgCommitReleaseResult layout changed.");
+static_assert(offsetof(RayletPgBundleSpec, required_resources) == 32,
+              "RayletPgBundleSpec required_resources offset mismatch.");
+static_assert(offsetof(RayletPgBundleAllocation, allocated_resources) == 40,
+              "RayletPgBundleAllocation allocated_resources offset mismatch.");
+static_assert(offsetof(RayletPgCommitReleaseResult, operation) == 32,
+              "RayletPgCommitReleaseResult operation offset mismatch.");
+static_assert(sizeof(RayletPgCommitReleaseOp) == 1,
+              "RayletPgCommitReleaseOp ABI width changed.");
+static_assert(sizeof(RayletPgResultCode) == 1, "RayletPgResultCode ABI width changed.");
 
 TEST(SchedulingFfiLayoutTest, RequestDecisionSizes) {
   EXPECT_EQ(sizeof(RayletResourceRequest), 40u);
   EXPECT_EQ(sizeof(RayletSchedulingRequest), 56u);
   EXPECT_EQ(sizeof(RayletSchedulingDecision), 24u);
+}
+
+TEST(SchedulingFfiLayoutTest, PlacementGroupReservationTypes) {
+  EXPECT_EQ(kRayletPgAbiVersion, 1u);
+  EXPECT_EQ(sizeof(RayletPgBundleSpec), 48u);
+  EXPECT_EQ(sizeof(RayletPgBundleAllocation), 56u);
+  EXPECT_EQ(sizeof(RayletPgCommitReleaseResult), 40u);
 }
 
 }  // namespace ray::raylet::ffi


### PR DESCRIPTION
Closes #38

## Changes
- `src/ray/raylet/scheduling/ffi/scheduling_ffi.h`: added ABI-safe placement-group bundle spec/allocation/result POD structs with versioning and ownership documentation.
- `rust/raylet-rs/src/scheduling_ffi.rs`: mirrored the new placement-group ABI structs and enums in Rust and added ABI version constant.
- `src/ray/raylet/scheduling/tests/scheduling_ffi_layout_test.cc`: added compile-time and test-time layout assertions for new placement-group ABI structs.

## Validation
- `cargo test -p raylet-rs ffi_layout_matches_cpp_expectations` (pass)
- `bazel test //src/ray/raylet/scheduling/tests:scheduling_ffi_layout_test` (pass)

All acceptance criteria met.