### PR TITLE
Add noop Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,9 @@
+# Minimal Buildkite pipeline for ray-no-fork.
+#
+# This is a noop pipeline that always passes. The goal is to verify
+# end-to-end plumbing: PR opened → Buildkite triggers → status check
+# appears on the PR. Once this works, expand to real build/test steps.
+
+steps:
+  - label: ":white_check_mark: noop"
+    command: "echo 'Buildkite pipeline is working. Expand this to run real tests.'"


### PR DESCRIPTION
## Summary
- Adds a minimal `.buildkite/pipeline.yml` that echoes success and exits 0
- Purpose: verify end-to-end Buildkite plumbing (PR opened → build triggers → status check appears)
- Once confirmed working, expand to real build/test steps