### PR TITLE
Replace noop Buildkite pipeline with C++ build step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,12 @@
-# Minimal Buildkite pipeline for ray-no-fork.
+# Buildkite pipeline for ray-no-fork C++ builds.
 #
-# This is a noop pipeline that always passes. The goal is to verify
-# end-to-end plumbing: PR opened → Buildkite triggers → status check
-# appears on the PR. Once this works, expand to real build/test steps.
+# Builds all C++ code inside a Docker container using Bazel.
+# The ci/docker/cpp-ci.Dockerfile provides the build environment
+# (clang-12, bazelisk, Python 3.10 for Bazel toolchain rules).
 
 steps:
-  - label: ":white_check_mark: noop"
-    command: "echo 'Buildkite pipeline is working. Expand this to run real tests.'"
+  - label: ":building_construction: Build C++ code"
+    commands:
+      - docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
+      - docker run --rm -v /tmp/artifacts:/artifact-mount ray-cpp-ci bazel build --config=ci //src/...
+    timeout_in_minutes: 90


### PR DESCRIPTION
## Summary
- Replaces the noop `pipeline.yml` with a step that builds C++ code using Bazel inside the CI Docker container
- Builds the Docker image from `ci/docker/cpp-ci.Dockerfile` (introduced in #57 / PR #60)
- Runs `bazel build --config=ci //src/...` with a 90-minute timeout

## Details
The pipeline now:
1. Builds the `ray-cpp-ci` Docker image from the Dockerfile created in #57
2. Runs `bazel build --config=ci //src/...` inside the container to compile all C++ code
3. Mounts `/tmp/artifacts` for compatibility with the existing Buildkite hooks

The `--config=ci` flag (defined in `.bazelrc` lines 177-189) enables colored output, disables curses, and sets progress reporting suitable for CI.

## Depends On
- #57 / PR #60 (CI Dockerfile must be merged first for the build step to succeed)

Closes #58