### PR TITLE
Add .bazelignore to exclude non-C++ directories from Bazel analysis

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,7 @@
+python
+java
+doc
+rllib
+release
+ci
+docker


### PR DESCRIPTION
## Summary

Add a `.bazelignore` file to prevent Bazel from scanning directories irrelevant to C++ builds.

## Changes

- Added `.bazelignore` excluding: `python`, `java`, `doc`, `rllib`, `release`, `ci`, `docker`
- `bazel/`, `thirdparty/`, `src/`, and `WORKSPACE` remain unaffected

This speeds up Bazel analysis and avoids errors from BUILD files that reference missing Python/Java toolchains.

Closes #64