### PR TITLE
Fix Buildkite pipeline: add Docker build step and remove noop

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,14 +3,18 @@
 # Requires the ray-cpp-ci Docker image (see ci/docker/).
 
 steps:
-  - label: ":white_check_mark: noop"
-    command: "echo 'Buildkite pipeline is working.'"
+  - label: ":docker: Build C++ CI image"
+    key: build-cpp-ci
+    commands:
+      - docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
+    timeout_in_minutes: 30
 
   - label: ":test_tube: C++ tests"
+    depends_on: build-cpp-ci
     commands:
       - >-
         docker run --rm
-        -v /tmp/bazel-testlogs:/artifact-mount
+        -v /tmp/artifacts:/artifact-mount
         ray-cpp-ci
         bash -c '
         bazel test
@@ -28,4 +32,4 @@ steps:
     timeout_in_minutes: 60
     soft_fail: true
     artifact_paths:
-      - "/tmp/bazel-testlogs/**/*"
+      - "/tmp/artifacts/**/*"


### PR DESCRIPTION
## Summary

- Remove the placeholder noop step that masked failures
- Add a Docker build step (`ray-cpp-ci`) that runs before the test step using `depends_on`
- Fix artifact volume mount from `/tmp/bazel-testlogs` to `/tmp/artifacts` to align with the pre-command/post-command hooks
- Update `artifact_paths` accordingly

Closes #63