### PR TITLE
Add missing system packages to C++ CI Dockerfile

### DIFF
--- a/ci/docker/cpp-ci.Dockerfile
+++ b/ci/docker/cpp-ci.Dockerfile
@@ -48,6 +48,15 @@ RUN apt-get update -qq && apt-get upgrade -qq -y \
         liblz4-dev \
         libunwind-dev \
         libncurses5 \
+        # perl is required by OpenSSL's ./Configure script (invoked by rules_foreign_cc)
+        perl \
+        # autoconf, automake, libtool are required by rules_foreign_cc for building
+        # third-party C/C++ libraries from source (e.g., jemalloc, OpenSSL)
+        autoconf \
+        automake \
+        libtool \
+        # pkg-config is needed by rules_foreign_cc to locate system libraries
+        pkg-config \
         # Python (needed by Bazel's Python toolchain rules)
         python-is-python3 \
         python3 \


### PR DESCRIPTION
## Summary

- Add `perl`, `autoconf`, `automake`, `libtool`, and `pkg-config` to the C++ CI Docker image

These packages are required by `rules_foreign_cc` for building third-party C/C++ libraries from source inside Bazel:

- **perl**: Required by OpenSSL's `./Configure` script (invoked by `rules_foreign_cc`)
- **autoconf, automake, libtool**: Required by `rules_foreign_cc` build steps for libraries like jemalloc and OpenSSL
- **pkg-config**: Needed by `rules_foreign_cc` to locate system libraries

This is the first step toward getting `bazel build --config=ci //src/...` to succeed inside the Docker image. Without these packages, the build fails immediately when trying to configure OpenSSL and other third-party dependencies.

Closes #65