### PR TITLE
Fix .bazelignore: remove java and release entries that break WORKSPACE loading

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,7 +1,5 @@
 python
-java
 doc
 rllib
-release
 ci
 docker


### PR DESCRIPTION
## Summary
- Remove `java` and `release` from `.bazelignore` so Bazel can resolve WORKSPACE-level references to these packages
- `bazel/ray_deps_build_all.bzl` loads from `//java:dependencies.bzl` and `WORKSPACE` references `//release:requirements_py310.txt`; ignoring those directories breaks workspace loading entirely

Closes #71