### PR TITLE
Add separate C++ build step before test step in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,18 @@ steps:
       - docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
     timeout_in_minutes: 30
 
-  - label: ":test_tube: C++ tests"
+  - label: ":hammer: C++ build"
+    key: build-cpp
     depends_on: build-cpp-ci
+    commands:
+      - >-
+        docker run --rm
+        ray-cpp-ci
+        bash -c 'bazel build --config=ci --jobs=HOST_CPUS*.5 //src/...'
+    timeout_in_minutes: 45
+
+  - label: ":test_tube: C++ tests"
+    depends_on: build-cpp
     commands:
       - >-
         docker run --rm


### PR DESCRIPTION
## Summary
- Adds a dedicated `bazel build` step between the Docker image build and the test step
- Build step is a hard failure (no `soft_fail`) so compilation breakage is immediately visible
- Test step now depends on the build step instead of the Docker image step

Pipeline structure: Docker image → **C++ build (hard fail)** → C++ tests (soft_fail)

Closes #73