### PR TITLE
Add C++ CI workflow and fix Dockerfile compiler inconsistency

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -1,0 +1,37 @@
+# GitHub Actions workflow that replicates the Buildkite C++ CI pipeline.
+# Builds the cpp-ci Docker image and runs `bazel build //src/...` inside it.
+
+name: C++ CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: cpp-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpp-build:
+    name: "C++ build"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          # GitHub runners have limited disk; reclaim space for the large Bazel build.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghcrunner
+          df -h /
+
+      - name: Build C++ CI Docker image
+        run: docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
+
+      - name: Bazel build //src/...
+        run: |
+          docker run --rm \
+            ray-cpp-ci \
+            bash -c 'bazel build --config=ci --jobs=HOST_CPUS*.5 //src/...'

--- a/ci/docker/cpp-ci.Dockerfile
+++ b/ci/docker/cpp-ci.Dockerfile
@@ -20,7 +20,7 @@ ENV TZ=America/Los_Angeles
 
 # Compiler flags — match base.build.Dockerfile
 ENV CC=clang
-ENV CXX=clang++-12
+ENV CXX=clang++
 
 # CI flags expected by install-bazel.sh and Bazel configs
 ENV BUILDKITE=true
@@ -66,8 +66,9 @@ RUN apt-get update -qq && apt-get upgrade -qq -y \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------- clang symlinks ----------
-# So that CC=clang / clang-format / clang-tidy resolve without version suffix.
+# So that CC=clang / CXX=clang++ / clang-format / clang-tidy resolve without version suffix.
 RUN ln -s /usr/bin/clang-12 /usr/bin/clang \
+    && ln -s /usr/bin/clang++-12 /usr/bin/clang++ \
     && ln -s /usr/bin/clang-format-12 /usr/bin/clang-format \
     && ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
 


### PR DESCRIPTION
## Summary

- **Add GitHub Actions C++ CI workflow** (`.github/workflows/cpp-ci.yml`) that replicates the Buildkite pipeline: builds the `cpp-ci` Docker image and runs `bazel build --config=ci //src/...` inside it. This lets us verify the C++ build passes without needing Buildkite access.
- **Fix CXX env var inconsistency** in `ci/docker/cpp-ci.Dockerfile`: `CC` was set to unversioned `clang` (via symlink) but `CXX` was `clang++-12` (versioned). Now both use unversioned names with proper symlinks (`clang` and `clang++`), which ensures `rules_foreign_cc` and other build tools find a consistent compiler pair.

Closes #79