### PR TITLE
Add C++ test catalog and triage scripts for failure analysis

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,11 @@ steps:
         2>&1;
         exit_code=$$?;
         cp -r $$(bazel info bazel-testlogs)/* /artifact-mount/ 2>/dev/null || true;
+        echo "--- :bar_chart: Test triage summary";
+        ci/triage-test-results.sh /artifact-mount 2>&1 || true;
+        echo "";
+        echo "--- :clipboard: Test target catalog";
+        python3 ci/catalog-test-targets.py . 2>&1 || true;
         exit $$exit_code
         '
     timeout_in_minutes: 60

--- a/ci/catalog-test-targets.py
+++ b/ci/catalog-test-targets.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""ci/catalog-test-targets.py — Static analysis of C++ test targets.
+
+Parses BUILD.bazel files under src/ray/ to extract ray_cc_test targets and
+their key properties. Outputs a categorized summary useful for test triage
+planning.
+
+Usage:
+    python3 ci/catalog-test-targets.py [--csv] [<repo-root>]
+
+Options:
+    --csv       Output raw CSV instead of formatted summary
+    <repo-root> Path to the repository root (default: ".")
+"""
+
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def find_build_files(root: str):
+    """Find all BUILD.bazel files under src/ray/."""
+    src_ray = Path(root) / "src" / "ray"
+    return sorted(src_ray.rglob("BUILD.bazel"))
+
+
+def extract_tests(build_file: Path, repo_root: str):
+    """Extract ray_cc_test targets from a BUILD.bazel file."""
+    content = build_file.read_text()
+    package = str(build_file.parent.relative_to(repo_root))
+    tests = []
+
+    # Find all ray_cc_test( blocks
+    # We need to handle nested parentheses properly
+    pattern = re.compile(r"ray_cc_test\(")
+    for m in pattern.finditer(content):
+        start = m.start()
+        # Find matching close paren
+        depth = 0
+        i = m.end() - 1  # position of opening paren
+        for i in range(m.end() - 1, len(content)):
+            if content[i] == "(":
+                depth += 1
+            elif content[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+        block = content[start : i + 1]
+
+        # Extract attributes
+        name = _extract_string(block, "name")
+        size = _extract_string(block, "size") or "default"
+        tags = _extract_list(block, "tags")
+        uses_redis = "redis-server" in block or "redis-cli" in block
+        has_exclusive = "exclusive" in tags
+
+        if name:
+            tests.append(
+                {
+                    "package": package,
+                    "name": name,
+                    "size": size,
+                    "tags": tags,
+                    "uses_redis": uses_redis,
+                    "has_exclusive": has_exclusive,
+                }
+            )
+
+    return tests
+
+
+def _extract_string(block: str, attr: str):
+    """Extract a string attribute value from a Bazel rule block."""
+    m = re.search(rf'{attr}\s*=\s*"([^"]*)"', block)
+    return m.group(1) if m else None
+
+
+def _extract_list(block: str, attr: str):
+    """Extract a list attribute from a Bazel rule block."""
+    m = re.search(rf"{attr}\s*=\s*\[([^\]]*)\]", block, re.DOTALL)
+    if not m:
+        return []
+    items_str = m.group(1)
+    return [s.strip().strip('"') for s in items_str.split(",") if s.strip().strip('"')]
+
+
+# Known categories for failure prediction
+REDIS_TESTS = {
+    "gcs_server_rpc_test",
+    "gcs_kv_manager_test",
+    "redis_gcs_table_storage_test",
+    "redis_store_client_test",
+    "chaos_redis_store_client_test",
+    "redis_async_context_test",
+    "global_state_accessor_test",
+    "gcs_client_test",
+    "gcs_client_reconnection_test",
+}
+
+
+def classify_test(test: dict) -> str:
+    """Classify a test into a predicted category."""
+    tags = test["tags"]
+    name = test["name"]
+
+    if "cgroup" in tags:
+        return "cgroup (filtered out)"
+    if test["uses_redis"] or name in REDIS_TESTS:
+        return "redis-dependent"
+    if any(t in tags for t in ["no_tsan", "no_ubsan"]):
+        return "sanitizer-sensitive"
+    return "standard"
+
+
+def print_csv(all_tests):
+    """Print all tests as CSV."""
+    print("package,name,size,tags,uses_redis,category")
+    for t in all_tests:
+        tags_str = ";".join(t["tags"]) if t["tags"] else ""
+        cat = classify_test(t)
+        print(f"{t['package']},{t['name']},{t['size']},{tags_str},{t['uses_redis']},{cat}")
+
+
+def print_summary(all_tests):
+    """Print a formatted summary."""
+    by_category = defaultdict(list)
+    by_subsystem = defaultdict(list)
+
+    for t in all_tests:
+        cat = classify_test(t)
+        by_category[cat].append(t)
+
+        # Extract subsystem from package path
+        parts = t["package"].split("/")
+        # e.g., src/ray/gcs/tests -> gcs, src/ray/core_worker/tests -> core_worker
+        if len(parts) >= 3:
+            subsystem = parts[2]  # src/ray/<subsystem>
+        else:
+            subsystem = "other"
+        by_subsystem[subsystem].append(t)
+
+    total = len(all_tests)
+    print(f"## C++ Test Target Catalog")
+    print()
+    print(f"**Total test targets:** {total}")
+    print()
+
+    # Category summary
+    print("### By Category")
+    print()
+    print("| Category | Count | Description |")
+    print("|----------|-------|-------------|")
+    cat_desc = {
+        "standard": "Expected to pass without special infrastructure",
+        "redis-dependent": "Requires redis-server and redis-cli binaries (see #80)",
+        "cgroup (filtered out)": "Filtered by --test_tag_filters=-cgroup",
+        "sanitizer-sensitive": "Has no_tsan/no_ubsan tags (may need care under sanitizers)",
+    }
+    for cat in ["standard", "redis-dependent", "sanitizer-sensitive", "cgroup (filtered out)"]:
+        tests = by_category.get(cat, [])
+        desc = cat_desc.get(cat, "")
+        if tests:
+            print(f"| {cat} | {len(tests)} | {desc} |")
+    print()
+
+    # Subsystem summary
+    print("### By Subsystem")
+    print()
+    print("| Subsystem | Total | Redis | Standard |")
+    print("|-----------|-------|-------|----------|")
+    for sub in sorted(by_subsystem.keys()):
+        tests = by_subsystem[sub]
+        redis_count = sum(1 for t in tests if classify_test(t) == "redis-dependent")
+        standard_count = sum(1 for t in tests if classify_test(t) == "standard")
+        print(f"| {sub} | {len(tests)} | {redis_count} | {standard_count} |")
+    print()
+
+    # Redis-dependent tests (detail)
+    redis_tests = by_category.get("redis-dependent", [])
+    if redis_tests:
+        print("### Redis-Dependent Tests (require #80)")
+        print()
+        for t in redis_tests:
+            print(f"- `{t['package']}:{t['name']}`")
+        print()
+
+    # Cgroup tests (detail)
+    cgroup_tests = by_category.get("cgroup (filtered out)", [])
+    if cgroup_tests:
+        print("### Cgroup Tests (filtered out by -cgroup)")
+        print()
+        for t in cgroup_tests:
+            print(f"- `{t['package']}:{t['name']}`")
+        print()
+
+    # Tests with exclusive tag
+    exclusive_tests = [t for t in all_tests if t["has_exclusive"]]
+    if exclusive_tests:
+        print("### Tests with `exclusive` Tag")
+        print()
+        for t in exclusive_tests:
+            print(f"- `{t['package']}:{t['name']}`")
+        print()
+
+    # Size distribution
+    sizes = defaultdict(int)
+    for t in all_tests:
+        sizes[t["size"]] += 1
+    print("### Size Distribution")
+    print()
+    print("| Size | Count |")
+    print("|------|-------|")
+    for size in ["small", "medium", "default"]:
+        if size in sizes:
+            print(f"| {size} | {sizes[size]} |")
+    print()
+
+
+def main():
+    csv_mode = "--csv" in sys.argv
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    repo_root = args[0] if args else "."
+
+    build_files = find_build_files(repo_root)
+    all_tests = []
+    for bf in build_files:
+        all_tests.extend(extract_tests(bf, repo_root))
+
+    if csv_mode:
+        print_csv(all_tests)
+    else:
+        print_summary(all_tests)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/triage-test-results.sh
+++ b/ci/triage-test-results.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# ci/triage-test-results.sh — Parse bazel test XML results and produce a
+# categorized triage summary.
+#
+# Usage: ci/triage-test-results.sh <testlogs-dir>
+#
+# The script reads JUnit XML files from bazel-testlogs and categorizes each
+# test target as PASSED, FAILED (with failure reason), or TIMEOUT.
+# Output is a Markdown summary suitable for Buildkite annotations or issue
+# comments.
+
+set -euo pipefail
+
+TESTLOGS_DIR="${1:?Usage: $0 <testlogs-dir>}"
+
+if [ ! -d "$TESTLOGS_DIR" ]; then
+  echo "Error: $TESTLOGS_DIR is not a directory" >&2
+  exit 1
+fi
+
+# Counters
+total=0
+passed=0
+failed=0
+timed_out=0
+no_result=0
+
+# Arrays for categorized failures
+declare -a redis_failures=()
+declare -a timeout_failures=()
+declare -a genuine_failures=()
+declare -a infra_failures=()
+declare -a passed_tests=()
+declare -a no_result_tests=()
+
+# Known redis-dependent tests
+REDIS_TESTS=(
+  "gcs_server_rpc_test"
+  "gcs_kv_manager_test"
+  "redis_gcs_table_storage_test"
+  "redis_store_client_test"
+  "chaos_redis_store_client_test"
+  "redis_async_context_test"
+  "global_state_accessor_test"
+  "gcs_client_test"
+  "gcs_client_reconnection_test"
+)
+
+is_redis_test() {
+  local name="$1"
+  for rt in "${REDIS_TESTS[@]}"; do
+    if [[ "$name" == "$rt" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Find all test.xml files
+while IFS= read -r xml_file; do
+  total=$((total + 1))
+
+  # Extract test target path from directory structure
+  # e.g., testlogs/src/ray/util/tests/array_test/test.xml -> //src/ray/util/tests:array_test
+  rel_path="${xml_file#"$TESTLOGS_DIR"/}"
+  dir_path="$(dirname "$rel_path")"
+  test_name="$(basename "$dir_path")"
+  package_path="$(dirname "$dir_path")"
+
+  target="//${package_path}:${test_name}"
+
+  # Parse XML for pass/fail status
+  # Look for failures, errors, and time attributes
+  if ! [ -s "$xml_file" ]; then
+    no_result=$((no_result + 1))
+    no_result_tests+=("$target")
+    continue
+  fi
+
+  # Extract key attributes from the testsuite element
+  tests_attr=$(grep -oP 'tests="\K[0-9]+' "$xml_file" 2>/dev/null | head -1 || echo "0")
+  failures_attr=$(grep -oP 'failures="\K[0-9]+' "$xml_file" 2>/dev/null | head -1 || echo "0")
+  errors_attr=$(grep -oP 'errors="\K[0-9]+' "$xml_file" 2>/dev/null | head -1 || echo "0")
+  time_attr=$(grep -oP 'time="\K[0-9.]+' "$xml_file" 2>/dev/null | head -1 || echo "0")
+
+  # Check for timeout markers in the XML
+  has_timeout=false
+  if grep -q 'TIMEOUT' "$xml_file" 2>/dev/null; then
+    has_timeout=true
+  fi
+
+  if [ "$failures_attr" = "0" ] && [ "$errors_attr" = "0" ] && [ "$tests_attr" != "0" ]; then
+    passed=$((passed + 1))
+    passed_tests+=("$target")
+  elif $has_timeout; then
+    timed_out=$((timed_out + 1))
+    timeout_failures+=("$target (${time_attr}s)")
+  else
+    failed=$((failed + 1))
+
+    # Categorize the failure
+    if is_redis_test "$test_name"; then
+      redis_failures+=("$target")
+    elif grep -qiE 'connection refused|address already in use|bind.*failed|port.*in use' "$xml_file" 2>/dev/null; then
+      infra_failures+=("$target")
+    else
+      genuine_failures+=("$target")
+    fi
+  fi
+done < <(find "$TESTLOGS_DIR" -name "test.xml" -type f | sort)
+
+# Also check for test logs without XML (crashed before producing results)
+while IFS= read -r log_file; do
+  rel_path="${log_file#"$TESTLOGS_DIR"/}"
+  dir_path="$(dirname "$rel_path")"
+  test_name="$(basename "$dir_path")"
+  xml_file="$dir_path/test.xml"
+
+  # Skip if we already processed the XML
+  if [ -f "$TESTLOGS_DIR/$xml_file" ]; then
+    continue
+  fi
+
+  target="//${dir_path%%/test.log}:${test_name}"
+
+  # Check if test log indicates a crash or infrastructure issue
+  if grep -qiE 'killed|signal|segfault|oom' "$log_file" 2>/dev/null; then
+    infra_failures+=("$target (crashed)")
+    failed=$((failed + 1))
+    total=$((total + 1))
+  fi
+done < <(find "$TESTLOGS_DIR" -name "test.log" -type f | sort)
+
+# Count expected targets from catalog (if available)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+expected_total=""
+if command -v python3 &>/dev/null && [ -f "$SCRIPT_DIR/catalog-test-targets.py" ]; then
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  # Count non-cgroup tests (cgroup tests are filtered by --test_tag_filters=-cgroup)
+  expected_total=$(python3 "$SCRIPT_DIR/catalog-test-targets.py" --csv "$repo_root" 2>/dev/null \
+    | tail -n +2 \
+    | grep -cv 'cgroup (filtered out)' || echo "")
+fi
+
+# Output summary
+total_label="$total"
+if [ -n "$expected_total" ] && [ "$expected_total" != "$total" ]; then
+  total_label="$total / $expected_total expected"
+fi
+
+cat <<EOF
+## C++ Test Triage Summary
+
+| Category | Count |
+|----------|-------|
+| **Total test targets** | $total_label |
+| ✅ Passed | $passed |
+| ❌ Failed | $failed |
+| ⏰ Timed out | $timed_out |
+| ❓ No result | $no_result |
+
+EOF
+
+if [ ${#redis_failures[@]} -gt 0 ]; then
+  echo "### 🔴 Redis-dependent failures (${#redis_failures[@]})"
+  echo ""
+  echo "These tests require \`redis-server\` and \`redis-cli\` at runtime."
+  echo "See issue #80 for the fix."
+  echo ""
+  for t in "${redis_failures[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+fi
+
+if [ ${#timeout_failures[@]} -gt 0 ]; then
+  echo "### ⏰ Timeout failures (${#timeout_failures[@]})"
+  echo ""
+  for t in "${timeout_failures[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+fi
+
+if [ ${#infra_failures[@]} -gt 0 ]; then
+  echo "### 🟡 Infrastructure failures (${#infra_failures[@]})"
+  echo ""
+  echo "Tests that failed due to missing runtime deps, port conflicts, or crashes."
+  echo ""
+  for t in "${infra_failures[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+fi
+
+if [ ${#genuine_failures[@]} -gt 0 ]; then
+  echo "### 🔴 Genuine test failures (${#genuine_failures[@]})"
+  echo ""
+  for t in "${genuine_failures[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+fi
+
+if [ ${#no_result_tests[@]} -gt 0 ]; then
+  echo "### ❓ No result / empty XML (${#no_result_tests[@]})"
+  echo ""
+  for t in "${no_result_tests[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+fi
+
+if [ ${#passed_tests[@]} -gt 0 ]; then
+  echo "<details>"
+  echo "<summary>✅ Passed tests (${#passed_tests[@]})</summary>"
+  echo ""
+  for t in "${passed_tests[@]}"; do
+    echo "- \`$t\`"
+  done
+  echo ""
+  echo "</details>"
+fi


### PR DESCRIPTION
## Summary

- Add `ci/catalog-test-targets.py` — static analysis of all 165 C++ test targets from BUILD.bazel files, categorizing by subsystem, redis dependency, tags, and predicted failure category
- Add `ci/triage-test-results.sh` — parses JUnit XML test results post-run and produces categorized Markdown summary (redis failures, timeouts, infra issues, genuine failures)
- Update `pipeline.yml` to run both scripts after tests complete, providing triage summary + target catalog in Buildkite output

### Test Catalog Findings

| Category | Count |
|----------|-------|
| Standard (expected to pass) | 146 |
| Redis-dependent (needs #80) | 9 |
| Sanitizer-sensitive | 7 |
| Cgroup (filtered out) | 3 |

The 9 redis-dependent tests are tracked in #80. The remaining 146 standard tests should pass once compilation (#79) succeeds.

Closes #81