### PR TITLE
Fix Dockerfile: remove deadsnakes PPA dependency for Python 3.10

### DIFF
--- a/ci/docker/cpp-ci.Dockerfile
+++ b/ci/docker/cpp-ci.Dockerfile
@@ -57,12 +57,11 @@ RUN apt-get update -qq && apt-get upgrade -qq -y \
         libtool \
         # pkg-config is needed by rules_foreign_cc to locate system libraries
         pkg-config \
-        # Python (needed by Bazel's Python toolchain rules)
+        # Python (needed by Bazel's Python toolchain rules and gRPC's python_configure)
         python-is-python3 \
         python3 \
+        python3-dev \
         python3-pip \
-        # deadsnakes PPA prerequisites
-        software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------- clang symlinks ----------
@@ -70,22 +69,6 @@ RUN apt-get update -qq && apt-get upgrade -qq -y \
 RUN ln -s /usr/bin/clang-12 /usr/bin/clang \
     && ln -s /usr/bin/clang-format-12 /usr/bin/clang-format \
     && ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
-
-# ---------- Python 3.10 ----------
-# Bazel's Python toolchain rules require Python 3.10.
-# We install it from the deadsnakes PPA, which is simpler and more
-# reproducible in a Dockerfile than the conda-based miniforge approach.
-RUN add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update -qq \
-    && apt-get install -y -qq --no-install-recommends \
-        python3.10 \
-        python3.10-dev \
-        python3.10-distutils \
-        python3.10-venv \
-    && rm -rf /var/lib/apt/lists/* \
-    # Make python3.10 the default python3 / python
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 
 # ---------- Bazel (via bazelisk) ----------
 # Matches ci/env/install-bazel.sh — installs bazelisk v1.16.0 as /bin/bazel.


### PR DESCRIPTION
## Summary

- Remove the deadsnakes PPA section from `ci/docker/cpp-ci.Dockerfile` — the PPA no longer provides `python3.10` packages for Ubuntu Focal, breaking Docker builds in CI
- Add `python3-dev` to the main apt install block (needed by gRPC's `python_configure` for `Python.h`)
- Remove `software-properties-common` (only needed for `add-apt-repository`, which is no longer used)

The hermetic Python 3.10 toolchain (`python_register_toolchains` in WORKSPACE) downloads its own interpreter, so system `python3.10` was never needed for C++ builds.

Closes #85