### PR TITLE
Add C++ test step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -1,0 +1,87 @@
+# GitHub Actions workflow for C++ CI builds and tests.
+#
+# Mirrors the Buildkite pipeline (.buildkite/pipeline.yml) for environments
+# where Buildkite is not connected.
+
+name: C++ CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  cpp-build:
+    name: "C++ Build"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          # GHA runners have ~14GB free; Docker image + Bazel need ~30GB+
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/share/swift /opt/hostedtoolcache
+          docker system prune -af || true
+          df -h /
+
+      - name: Build Docker image
+        run: docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
+
+      - name: Bazel build
+        run: >-
+          docker run --rm
+          ray-cpp-ci
+          bash -c 'bazel build --config=ci --jobs=HOST_CPUS*.5 //src/...'
+
+  cpp-test:
+    name: "C++ Tests"
+    runs-on: ubuntu-latest
+    needs: cpp-build
+    timeout-minutes: 60
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/share/swift /opt/hostedtoolcache
+          docker system prune -af || true
+          df -h /
+
+      - name: Build Docker image
+        run: docker build -t ray-cpp-ci -f ci/docker/cpp-ci.Dockerfile .
+
+      - name: Run C++ tests
+        run: |
+          mkdir -p /tmp/test-artifacts
+          docker run --rm \
+            -v /tmp/test-artifacts:/artifact-mount \
+            ray-cpp-ci \
+            bash -c '
+            bazel test \
+              --config=ci \
+              --test_tag_filters=-cgroup \
+              --jobs=HOST_CPUS*.5 \
+              --test_timeout=300,600,1200,3600 \
+              --local_test_jobs=HOST_CPUS*.5 \
+              //src/... \
+              2>&1; \
+            exit_code=$?; \
+            cp -r $(bazel info bazel-testlogs)/* /artifact-mount/ 2>/dev/null || true; \
+            exit $exit_code
+            '
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-test-logs
+          path: /tmp/test-artifacts/
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cpp-ci.yml` with a `cpp-build` job (Docker image build + `bazel build`) and a `cpp-test` job (runs `bazel test` with the same flags as the Buildkite pipeline)
- Test job uses `continue-on-error: true` (matching Buildkite's `soft_fail`) and uploads `bazel-testlogs` as artifacts
- Both jobs free disk space to fit within GHA runner limits

Closes #88