### PR TITLE
Generalize ci/ray_ci Docker registry auth to support GHCR

### DIFF
--- a/ci/ray_ci/anyscale_docker_container.py
+++ b/ci/ray_ci/anyscale_docker_container.py
@@ -4,8 +4,8 @@ import subprocess
 from ci.ray_ci.container import (
     _AZURE_REGISTRY_NAME,
     _DOCKER_AZURE_REGISTRY,
-    _DOCKER_ECR_REPO,
     _DOCKER_GCP_REGISTRY,
+    _DOCKER_WORK_REPO,
 )
 from ci.ray_ci.docker_container import DockerContainer
 
@@ -21,7 +21,7 @@ class AnyscaleDockerContainer(DockerContainer):
         """
         Build and publish anyscale docker images
         """
-        aws_registry = _DOCKER_ECR_REPO.split("/")[0]
+        aws_registry = _DOCKER_WORK_REPO.split("/")[0]
         gcp_registry = _DOCKER_GCP_REGISTRY
         azure_registry = _DOCKER_AZURE_REGISTRY
         tag = self._get_canonical_tag()

--- a/ci/ray_ci/automation/copy_wanda_image.py
+++ b/ci/ray_ci/automation/copy_wanda_image.py
@@ -25,7 +25,7 @@ from ci.ray_ci.automation.crane_lib import (
     call_crane_copy,
     call_crane_manifest,
 )
-from ci.ray_ci.utils import ecr_docker_login
+from ci.ray_ci.utils import docker_login
 
 # Configure logging
 logging.basicConfig(
@@ -156,7 +156,7 @@ def main(
     # Authenticate with ECR (source registry). Docker Hub authentication is
     # handled by copy_files.py.
     ecr_registry = rayci_work_repo.split("/")[0]
-    ecr_docker_login(ecr_registry)
+    docker_login(ecr_registry)
 
     logger.info("Verifying source image in Wanda cache...")
     if not _image_exists(source_tag):

--- a/ci/ray_ci/automation/extract_wanda_wheels.py
+++ b/ci/ray_ci/automation/extract_wanda_wheels.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 
 from ci.ray_ci.automation.crane_lib import call_crane_export
-from ci.ray_ci.utils import ecr_docker_login, logger
+from ci.ray_ci.utils import docker_login, logger
 
 
 def _default_output_dir() -> str:
@@ -68,7 +68,7 @@ def main(
     logger.info(f"Extracting wheels from: {wanda_image}")
 
     ecr_registry = rayci_work_repo.split("/")[0]
-    ecr_docker_login(ecr_registry)
+    docker_login(ecr_registry)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         call_crane_export(wanda_image, tmpdir)

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -22,7 +22,7 @@ from ci.ray_ci.docker_container import (
     RayType,
 )
 from ci.ray_ci.ray_image import IMAGE_TYPE_CONFIG, RayImage, RayImageError
-from ci.ray_ci.utils import ci_init, ecr_docker_login
+from ci.ray_ci.utils import ci_init, docker_login
 
 from ray_release.configs.global_config import get_global_config
 
@@ -265,7 +265,7 @@ def main(
     logger.info(f"Processing {len(platforms)} platform(s): {platforms}")
 
     ecr_registry = rayci_work_repo.split("/")[0]
-    ecr_docker_login(ecr_registry)
+    docker_login(ecr_registry)
 
     all_tags = []
     for plat in platforms:

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -32,7 +32,7 @@ from ci.ray_ci.automation.image_tags_lib import (
     image_exists,
 )
 from ci.ray_ci.container import _AZURE_REGISTRY_NAME
-from ci.ray_ci.utils import ci_init, ecr_docker_login
+from ci.ray_ci.utils import ci_init, docker_login
 
 from ray_release.configs.global_config import get_global_config
 
@@ -300,7 +300,7 @@ def main(
         return
 
     # Authenticate with all registries
-    ecr_docker_login(ecr_registry)
+    docker_login(ecr_registry)
     _run_gcloud_docker_login()
     _run_azure_docker_login()
 

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -467,7 +467,7 @@ class TestMultiplePlatforms:
     WORK_REPO = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
 
     @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
-    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.docker_login")
     @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
     @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
     @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
@@ -528,7 +528,7 @@ class TestMultiplePlatforms:
         )
 
     @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
-    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.docker_login")
     @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
     @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
     @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -10,10 +10,10 @@ from ci.ray_ci.configs import (
     DEFAULT_PYTHON_VERSION,
     PYTHON_VERSIONS,
 )
-from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.container import _DOCKER_WORK_REPO
 from ci.ray_ci.docker_container import PLATFORMS_RAY, RayType
 from ci.ray_ci.ray_docker_container import RayDockerContainer
-from ci.ray_ci.utils import ci_init, ecr_docker_login, logger
+from ci.ray_ci.utils import ci_init, docker_login, logger
 from ci.ray_ci.windows_builder_container import WindowsBuilderContainer
 
 
@@ -84,7 +84,7 @@ def main(
     """
     Build a wheel or jar artifact
     """
-    ecr_docker_login(_DOCKER_ECR_REPO.split("/")[0])
+    docker_login(_DOCKER_WORK_REPO.split("/")[0])
     ci_init()
     if artifact_type == "wheel":
         logger.info(f"Building wheel for {python_version}")

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -22,10 +22,12 @@ A copy of this license is made available in this container at /NGC-DL-CONTAINER-
 """
 
 _AZURE_REGISTRY_NAME = "rayreleasetest"
-_DOCKER_ECR_REPO = os.environ.get(
+_DOCKER_WORK_REPO = os.environ.get(
     "RAYCI_WORK_REPO",
     "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp",
 )
+# Backward-compatible alias
+_DOCKER_ECR_REPO = _DOCKER_WORK_REPO
 _DOCKER_GCP_REGISTRY = os.environ.get(
     "RAYCI_GCP_REGISTRY",
     "us-west1-docker.pkg.dev/anyscale-oss-ci",
@@ -54,8 +56,8 @@ def get_docker_image(docker_tag: str, build_id: Optional[str] = None) -> str:
     if not build_id:
         build_id = _RAYCI_BUILD_ID
     if build_id:
-        return f"{_DOCKER_ECR_REPO}:{build_id}-{docker_tag}"
-    return f"{_DOCKER_ECR_REPO}:{docker_tag}"
+        return f"{_DOCKER_WORK_REPO}:{build_id}-{docker_tag}"
+    return f"{_DOCKER_WORK_REPO}:{docker_tag}"
 
 
 class Container(abc.ABC):

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 
 from ci.ray_ci.configs import DEFAULT_ARCHITECTURE, PYTHON_VERSIONS
-from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.container import _DOCKER_WORK_REPO
 from ci.ray_ci.docker_container import RAY_REPO_MAP, DockerContainer, RayType
 from ci.ray_ci.utils import RAY_VERSION, docker_pull
 
@@ -38,7 +38,7 @@ class RayDockerContainer(DockerContainer):
         image_repo = RAY_REPO_MAP[self.image_type]
 
         base_image = (
-            f"{_DOCKER_ECR_REPO}:{rayci_build_id}"
+            f"{_DOCKER_WORK_REPO}:{rayci_build_id}"
             f"-{image_repo}-py{self.python_version}-{self.platform}-{suffix}"
         )
 

--- a/ci/ray_ci/test_anyscale_docker_container.py
+++ b/ci/ray_ci/test_anyscale_docker_container.py
@@ -8,8 +8,8 @@ import pytest
 from ci.ray_ci.anyscale_docker_container import AnyscaleDockerContainer
 from ci.ray_ci.container import (
     _DOCKER_AZURE_REGISTRY,
-    _DOCKER_ECR_REPO,
     _DOCKER_GCP_REGISTRY,
+    _DOCKER_WORK_REPO,
 )
 from ci.ray_ci.test_base import RayCITestBase
 
@@ -35,7 +35,7 @@ class TestAnyscaleDockerContainer(RayCITestBase):
             )
             container.run()
             cmd = self.cmds[-1]
-            aws_ecr = _DOCKER_ECR_REPO.split("/")[0]
+            aws_ecr = _DOCKER_WORK_REPO.split("/")[0]
             aws_prj = f"{aws_ecr}/anyscale/ray-ml"
             gcp_prj = f"{_DOCKER_GCP_REGISTRY}/anyscale/ray-ml"
             azure_prj = f"{_DOCKER_AZURE_REGISTRY}/anyscale/ray-ml"

--- a/ci/ray_ci/test_container.py
+++ b/ci/ray_ci/test_container.py
@@ -2,14 +2,14 @@ import sys
 
 import pytest
 
-from ci.ray_ci.container import _DOCKER_ECR_REPO, get_docker_image
+from ci.ray_ci.container import _DOCKER_WORK_REPO, get_docker_image
 
 
 def test_get_docker_image() -> None:
-    assert get_docker_image("test-image") == f"{_DOCKER_ECR_REPO}:test-image"
+    assert get_docker_image("test-image") == f"{_DOCKER_WORK_REPO}:test-image"
     assert (
         get_docker_image("test-image", "a1b2c3")
-        == f"{_DOCKER_ECR_REPO}:a1b2c3-test-image"
+        == f"{_DOCKER_WORK_REPO}:a1b2c3-test-image"
     )
 
 

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.container import _DOCKER_WORK_REPO
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.tester_container import RUN_PER_FLAKY_TEST
 from ci.ray_ci.utils import chunk_into_n, ci_init
@@ -166,7 +166,7 @@ def test_ray_installation() -> None:
 
     with mock.patch("subprocess.check_call", side_effect=_mock_subprocess):
         LinuxTesterContainer("team", build_type="debug")
-        docker_image = f"{_DOCKER_ECR_REPO}:team"
+        docker_image = f"{_DOCKER_WORK_REPO}:team"
         assert install_ray_cmds[-1] == [
             "docker",
             "build",
@@ -194,7 +194,7 @@ def test_ray_installation_wheel() -> None:
 
     with mock.patch("subprocess.check_call", side_effect=_mock_subprocess):
         LinuxTesterContainer("team", build_type="wheel", python_version="3.10")
-        docker_image = f"{_DOCKER_ECR_REPO}:team"
+        docker_image = f"{_DOCKER_WORK_REPO}:team"
         cmd = install_ray_cmds[-1]
         assert cmd[0:6] == [
             "docker",

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
-from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.container import _DOCKER_WORK_REPO
 from ci.ray_ci.docker_container import GPU_PLATFORM
 from ci.ray_ci.ray_docker_container import RayDockerContainer
 from ci.ray_ci.test_base import RayCITestBase
@@ -44,7 +44,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert cmd == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
                 f"rayproject/ray:{sha}-{pv}-cu124 "
                 f"ray:{sha}-{pv}-cu124_pip-freeze.txt"
             )
@@ -60,7 +60,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert cmd == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
                 f"rayproject/ray-llm:{sha}-{pv}-cu128 "
                 f"ray-llm:{sha}-{pv}-cu128_pip-freeze.txt"
             )
@@ -76,7 +76,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert cmd == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
                 f"rayproject/ray-ml:{sha}-{pv}-cpu "
                 f"ray-ml:{sha}-{pv}-cpu_pip-freeze.txt"
             )
@@ -113,7 +113,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
                 f"rayproject/ray:{sha}-{pv}-cu121 "
                 f"ray:{sha}-{pv}-cu121_pip-freeze.txt"
             )
@@ -138,7 +138,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
                 f"rayproject/ray-llm:{sha}-{pv}-cu128 "
                 f"ray-llm:{sha}-{pv}-cu128_pip-freeze.txt"
             )
@@ -162,7 +162,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
                 f"rayproject/ray-ml:{sha}-{pv}-cpu "
                 f"ray-ml:{sha}-{pv}-cpu_pip-freeze.txt"
             )
@@ -206,7 +206,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-py{v}-{cuda}-base "
                 f"rayproject/ray:{sha}-{pv}-cu118 "
                 f"ray:{sha}-{pv}-cu118_pip-freeze.txt"
             )
@@ -223,7 +223,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-llm-py{v}-{cuda}-base "
                 f"rayproject/ray-llm:{sha}-{pv}-cu128 "
                 f"ray-llm:{sha}-{pv}-cu128_pip-freeze.txt"
             )
@@ -239,7 +239,7 @@ class TestRayDockerContainer(RayCITestBase):
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
-                f"{_DOCKER_ECR_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
+                f"{_DOCKER_WORK_REPO}:{ray_ci_build_id}-ray-ml-py{v}-cpu-base "
                 f"rayproject/ray-ml:{sha}-{pv}-cpu "
                 f"ray-ml:{sha}-{pv}-cpu_pip-freeze.txt"
             )

--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import logging
 import sys
 from typing import List
 from unittest import mock
@@ -8,7 +9,9 @@ import pytest
 
 from ci.ray_ci.utils import (
     chunk_into_n,
-    ecr_docker_login,
+    docker_login,
+    _ecr_docker_login,
+    _ghcr_docker_login,
     filter_tests,
     get_flaky_test_names,
 )
@@ -22,8 +25,7 @@ def test_chunk_into_n() -> None:
     assert chunk_into_n([1, 2], 1) == [[1, 2]]
 
 
-@mock.patch("boto3.client")
-def test_ecr_docker_login(mock_client) -> None:
+def test_ecr_docker_login() -> None:
     def _mock_subprocess_run(
         cmd: List[str],
         stdin=None,
@@ -33,14 +35,62 @@ def test_ecr_docker_login(mock_client) -> None:
     ) -> None:
         assert stdin.read() == b"password"
 
-    mock_client.return_value.get_authorization_token.return_value = {
+    mock_boto3 = mock.MagicMock()
+    mock_boto3.client.return_value.get_authorization_token.return_value = {
         "authorizationData": [
             {"authorizationToken": base64.b64encode(b"AWS:password")},
         ],
     }
 
-    with mock.patch("subprocess.run", side_effect=_mock_subprocess_run):
-        ecr_docker_login("docker_ecr")
+    with mock.patch.dict("sys.modules", {"boto3": mock_boto3}), \
+         mock.patch("subprocess.run", side_effect=_mock_subprocess_run):
+        _ecr_docker_login("docker_ecr")
+
+
+def test_ghcr_docker_login() -> None:
+    def _mock_subprocess_run(
+        cmd: List[str],
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        check=True,
+    ) -> None:
+        assert stdin.read() == b"my-ghcr-token"
+        assert cmd[-1] == "ghcr.io"
+        assert cmd[3] == "USERNAME"
+
+    with mock.patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "my-ghcr-token"}, clear=False
+    ), mock.patch("subprocess.run", side_effect=_mock_subprocess_run):
+        _ghcr_docker_login("ghcr.io")
+
+
+def test_ghcr_docker_login_missing_token() -> None:
+    with mock.patch.dict(
+        "os.environ", {}, clear=True
+    ):
+        with pytest.raises(RuntimeError, match="GITHUB_TOKEN or GHCR_TOKEN"):
+            _ghcr_docker_login("ghcr.io")
+
+
+def test_docker_login_dispatches_ecr() -> None:
+    with mock.patch("ci.ray_ci.utils._ecr_docker_login") as mock_ecr:
+        docker_login("029272617770.dkr.ecr.us-west-2.amazonaws.com")
+        mock_ecr.assert_called_once_with(
+            "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+        )
+
+
+def test_docker_login_dispatches_ghcr() -> None:
+    with mock.patch("ci.ray_ci.utils._ghcr_docker_login") as mock_ghcr:
+        docker_login("ghcr.io")
+        mock_ghcr.assert_called_once_with("ghcr.io")
+
+
+def test_docker_login_unknown_registry(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        docker_login("registry.example.com")
+    assert "Unknown registry type" in caplog.text
 
 
 def _make_test(name: str, state: str, team: str) -> Test:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -8,10 +8,10 @@ import yaml
 from ci.ray_ci.configs import (
     PYTHON_VERSIONS,
 )
-from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.container import _DOCKER_WORK_REPO
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import ci_init, ecr_docker_login
+from ci.ray_ci.utils import ci_init, docker_login
 from ci.ray_ci.windows_tester_container import WindowsTesterContainer
 
 from ray_release.test import Test, TestState
@@ -225,7 +225,7 @@ def main(
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
     ci_init()
-    ecr_docker_login(_DOCKER_ECR_REPO.split("/")[0])
+    docker_login(_DOCKER_WORK_REPO.split("/")[0])
 
     bisect_run_test_target = bisect_run_test_target or os.environ.get(
         "RAYCI_BISECT_TEST_TARGET"

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -8,8 +8,6 @@ import tempfile
 from math import ceil
 from typing import List
 
-import boto3
-
 import ci.ray_ci.bazel_sharding as bazel_sharding
 
 from ray_release.bazel import bazel_runfile
@@ -48,16 +46,49 @@ def shard_tests(
     return bazel_sharding.main(test_targets, index=shard_id, count=shard_count)
 
 
-def ecr_docker_login(docker_ecr: str) -> None:
+def docker_login(registry: str) -> None:
+    """Login to a container registry, auto-detecting the auth mechanism.
+
+    Supports:
+    - ECR (*.dkr.ecr.*.amazonaws.com): uses boto3 for auth
+    - GHCR (ghcr.io): uses GITHUB_TOKEN or GHCR_TOKEN env var
+    - Other: logs a warning and skips login
     """
-    Login to ECR with AWS credentials
-    """
+    if ".dkr.ecr." in registry and ".amazonaws.com" in registry:
+        _ecr_docker_login(registry)
+    elif "ghcr.io" in registry:
+        _ghcr_docker_login(registry)
+    else:
+        logger.warning(
+            "Unknown registry type: %s, skipping docker login", registry
+        )
+
+
+def _ecr_docker_login(docker_ecr: str) -> None:
+    """Login to ECR with AWS credentials."""
+    import boto3
+
     token = boto3.client("ecr", region_name="us-west-2").get_authorization_token()
     user, password = (
         base64.b64decode(token["authorizationData"][0]["authorizationToken"])
         .decode("utf-8")
         .split(":")
     )
+    _docker_login_with_token(docker_ecr, user, password)
+
+
+def _ghcr_docker_login(registry: str) -> None:
+    """Login to GHCR using GITHUB_TOKEN or GHCR_TOKEN env var."""
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GHCR_TOKEN", "")
+    if not token:
+        raise RuntimeError(
+            "GITHUB_TOKEN or GHCR_TOKEN env var required for GHCR auth"
+        )
+    _docker_login_with_token(registry, "USERNAME", token)
+
+
+def _docker_login_with_token(registry: str, user: str, password: str) -> None:
+    """Run docker login with the given credentials via stdin."""
     with tempfile.TemporaryFile() as f:
         f.write(bytes(password, "utf-8"))
         f.flush()
@@ -70,13 +101,17 @@ def ecr_docker_login(docker_ecr: str) -> None:
                 "--username",
                 user,
                 "--password-stdin",
-                docker_ecr,
+                registry,
             ],
             stdin=f,
             stdout=sys.stdout,
             stderr=sys.stderr,
             check=True,
         )
+
+
+# Keep backward-compatible alias
+ecr_docker_login = _ecr_docker_login
 
 
 def docker_pull(image: str) -> None:


### PR DESCRIPTION
## Summary

- Replaces `ecr_docker_login()` with `docker_login()` that auto-detects registry type from URL pattern (ECR, GHCR, or unknown)
- Makes `boto3` import conditional — only loaded when ECR auth is needed, so GHCR-only setups don't require the AWS SDK
- Renames `_DOCKER_ECR_REPO` to `_DOCKER_WORK_REPO` across all 15 consuming files for clarity (it's registry-agnostic)
- Backward-compatible aliases preserved for both `ecr_docker_login` and `_DOCKER_ECR_REPO`
- Adds tests for GHCR login path, dispatch logic, and missing token error handling

Closes #101