### PR TITLE
Simplify pipeline.yml bootstrap to use pre-installed rayci binary

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,10 @@
 # Buildkite pipeline entrypoint.
 #
-# This single bootstrap step downloads the rayci binary (version pinned in
-# .rayciversion) and uses it to generate and upload the real pipeline from
-# the .buildkite/*.rayci.yml definitions.
+# This bootstrap step uses the pre-installed rayci binary to generate and
+# upload the real pipeline from the .buildkite/*.rayci.yml definitions.
+# The expected rayci version is documented in .rayciversion.
 
 steps:
   - label: ":pipeline: bootstrap rayci"
     commands:
-      - curl -sfL "https://raw.githubusercontent.com/ray-project/rayci/stable/run_rayci.sh" | bash -s -- -upload -config .buildkite/fork-config.yaml
+      - /usr/local/bin/rayci -upload -config .buildkite/fork-config.yaml


### PR DESCRIPTION
## Summary

Replace the `curl | bash` bootstrap in `.buildkite/pipeline.yml` with a direct invocation of `/usr/local/bin/rayci`, which is already pre-installed on the Buildkite agents.

**Changes:**
- Replaced `curl -sfL ... | bash -s -- -upload -config .buildkite/fork-config.yaml` with `/usr/local/bin/rayci -upload -config .buildkite/fork-config.yaml`
- Updated header comment to reflect the new approach
- `.rayciversion` is preserved as documentation of the expected version

**Benefits:**
- Eliminates GitHub rate-limiting risk on release downloads
- Removes network failure mode during the most critical pipeline step
- Saves ~5-10 seconds of latency per build

Closes #108