### PR TITLE
Fix fork-config.yaml: map all missing instance types to unblock rayci pipeline generation

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -24,6 +24,8 @@ forge_prefix: "cr.ray.io/rayproject/"
 # Buildkite agent queues for image-building steps.
 builder_queues:
   builder: "default"
+  builder-arm64: "default"
+  builder-windows: "default"
 
 # Buildkite agent queues for test/runner steps.
 # Map rayci instance types to queue names.  Using "default" everywhere
@@ -33,10 +35,17 @@ runner_queues:
   small: "default"
   medium: "default"
   large: "default"
+  gpu: "default"
+  gpu-large: "default"
+  g6-large: "default"
+  macos-arm64: "default"
+  medium-arm64: "default"
+  windows: "default"
 
 env:
   BUILDKITE_BAZEL_CACHE_URL: ""
   RAYCI_STAGE: "premerge"
+  RAYCI_DISABLE_TEST_DB: "1"
 
 # Tags that cause steps to be unconditionally skipped.
 skip_tags:


### PR DESCRIPTION
## Summary

- Add 6 missing `runner_queues` entries (`gpu`, `gpu-large`, `g6-large`, `macos-arm64`, `medium-arm64`, `windows`) so the rayci binary no longer errors with "unknown instance type"
- Add 2 missing `builder_queues` entries (`builder-arm64`, `builder-windows`) for ARM64 and Windows image builds
- Add `RAYCI_DISABLE_TEST_DB: "1"` to the `env` section to disable the flaky-test S3 lookup that would fail without access to Ray's AWS account

All 12 unique instance types from `.buildkite/*.rayci.yml` are now mapped. This is purely a config fix — no changes to `.rayci.yml` files or CI code.

Closes #107