### PR TITLE
Support local Bazel disk cache in CI build configuration

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -81,6 +81,10 @@ sudo ln -sf /usr/local/bin/python3.10 /usr/local/bin/python3
   echo "build --config=ci"
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
-    echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    else
+      echo "build:ci --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    fi
   fi
 } > "$HOME"/.bazelrc

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -45,7 +45,13 @@ echo \
 apt-get update
 apt-get install -y docker-ce-cli
 
-echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> /root/.bazelrc
+if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
+  if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+    echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> /root/.bazelrc
+  else
+    echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> /root/.bazelrc
+  fi
+fi
 
 EOF
 

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -138,7 +138,13 @@ set -euo pipefail
 {
   echo "build --config=ci"
   echo "build --announce_rc"
-  echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+  if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    else
+      echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    fi
+  fi
 } > ~/.bazelrc
 
 EOF

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -21,7 +21,11 @@ set -euo pipefail
   echo "build --config=ci"
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
-    echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    else
+      echo "build:ci --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    fi
   fi
 } > "$HOME"/.bazelrc
 

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -45,7 +45,11 @@ set -euo pipefail
   echo "build --config=ci"
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
-    echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    else
+      echo "build:ci --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+    fi
   fi
 } > "$HOME"/.bazelrc
 

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -115,9 +115,14 @@ if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
     echo "build --disk_cache=/tmp/bazel-cache" >> ~/.bazelrc
     echo "build --repository_cache=/tmp/bazel-repo-cache" >> ~/.bazelrc
   elif [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
-    echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
-    if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-      echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
+      if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+        echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+      fi
+    else
+      echo "Using local disk cache at ${BUILDKITE_BAZEL_CACHE_URL}"
+      echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
     fi
   fi
 fi

--- a/ci/ray_ci/windows/build_ray.sh
+++ b/ci/ray_ci/windows/build_ray.sh
@@ -13,12 +13,20 @@ cd /c/rayci
   echo "build --config=ci";
   # Set a shorter output_base to avoid long file paths that Windows can't handle.
   echo "startup --output_base=c:/bzl";
-  echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+  if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+      echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+    else
+      echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+    fi
+  fi
 } >> ~/.bazelrc
 
-if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  # Do not upload cache results for premerge pipeline
-  echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" == https://* ]]; then
+  if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+    # Do not upload cache results for premerge pipeline
+    echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+  fi
 fi
 
 # Fix network for remote caching

--- a/python/build-wheel-windows.sh
+++ b/python/build-wheel-windows.sh
@@ -75,11 +75,19 @@ build_wheel_windows() {
     echo "build --announce_rc";
     echo "build --config=ci";
     echo "startup --output_user_root=c:/raytmp";
-    echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
+      if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+        echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+      else
+        echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+      fi
+    fi
   } >> ~/.bazelrc
 
-  if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-    echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+  if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" == https://* ]]; then
+    if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+      echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+    fi
   fi
 
   local pyversion="${BUILD_ONE_PYTHON_ONLY}"


### PR DESCRIPTION
## Summary

- Detect whether `BUILDKITE_BAZEL_CACHE_URL` is an HTTP URL or a local filesystem path and use the appropriate Bazel flag (`--remote_cache` vs `--disk_cache`)
- All 8 files that consume `BUILDKITE_BAZEL_CACHE_URL` are updated: shell scripts, Dockerfiles, and Windows build scripts
- `--remote_upload_local_results` logic is preserved only for remote cache (not applicable for disk cache)

## Details

When `BUILDKITE_BAZEL_CACHE_URL` is set to a local path (e.g. `/var/cache/bazel-ci`), Bazel's `--remote_cache` flag doesn't work — it requires an HTTP/gRPC endpoint. This PR adds URL-vs-path detection so that local paths use `--disk_cache` instead.

The detection pattern (`[[ "$URL" == http://* ]] || [[ "$URL" == https://* ]]`) is simple and follows the existing precedent in `install-bazel.sh` where macOS already uses `--disk_cache`.

Closes #112