### PR TITLE
Replace curl-to-upstream in cicd.rayci.yml with pre-installed rayci binary

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -5,7 +5,7 @@ steps:
   - label: ":test_tube: test-rules"
     key: test-rules
     commands:
-      - curl -sfL "https://raw.githubusercontent.com/ray-project/rayci/stable/run_rayci.sh" | bash -s -- test-rules
+      - /usr/local/bin/rayci test-rules
     instance_type: small
     tags:
       - tools


### PR DESCRIPTION
## Summary

- Replace the `curl | bash` download of `run_rayci.sh` in the `test-rules` step with a direct call to `/usr/local/bin/rayci test-rules`, which is already pre-installed on Buildkite agents

This is the same pattern fixed in #108 for `pipeline.yml`. Removes a runtime dependency on upstream GitHub and avoids redundantly downloading a binary that's already installed.

Closes #114