### PR TITLE
Add fork-specific config to prevent upstream S3/ECR access

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -43,6 +43,7 @@ runner_queues:
   windows: "default"
 
 env:
+  RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"
   BUILDKITE_BAZEL_CACHE_URL: ""
   RAYCI_STAGE: "premerge"
   RAYCI_DISABLE_TEST_DB: "1"

--- a/ci/ray_ci/fork_config.yaml
+++ b/ci/ray_ci/fork_config.yaml
@@ -1,0 +1,29 @@
+# Fork-specific CI config. Loaded via RAYCI_GLOBAL_CONFIG env var.
+# This replaces oss_config.yaml to prevent any accidental access
+# to upstream Ray's AWS/GCP/Azure resources.
+
+release_byod:
+  ray_ecr: ""
+  byod_ecr: ""
+  byod_ecr_region: ""
+  aws_cr: ""
+  gcp_cr: ""
+  azure_cr: ""
+  aws2gce_credentials: ""
+
+ci_pipeline:
+  premerge: []
+  postmerge: []
+  buildkite_secret: ""
+
+state_machine:
+  disabled: 1
+  pr:
+    aws_bucket: ""
+  branch:
+    aws_bucket: ""
+
+release_image_step:
+  ray: ""
+  ray_ml: ""
+  ray_llm: ""


### PR DESCRIPTION
## Summary

- Creates `ci/ray_ci/fork_config.yaml` with all upstream references nullified (empty ECR/GCP/Azure/S3 values, empty pipeline UUIDs, `state_machine.disabled: 1`)
- Adds `RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"` to `.buildkite/fork-config.yaml` env block so Ray CI loads the fork config instead of `oss_config.yaml`

This provides defense-in-depth alongside the existing `RAYCI_DISABLE_TEST_DB=1` env var, ensuring the fork never accidentally contacts upstream Ray AWS/GCP/Azure resources even if that env var is removed.

Closes #115