### PR TITLE
Set ci_temp to /tmp/artifacts/ci-temp/ in fork-config.yaml

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -11,7 +11,7 @@
 ci_work_repo: "PLACEHOLDER_REGISTRY"
 
 # S3/GCS path for temp files shared across build steps (required).
-ci_temp: "PLACEHOLDER_CI_TEMP"
+ci_temp: "/tmp/artifacts/ci-temp/"
 
 # S3 bucket for build artifacts (optional but recommended).
 artifacts_bucket: ""


### PR DESCRIPTION
## Summary

- Sets `ci_temp` in `.buildkite/fork-config.yaml` from `PLACEHOLDER_CI_TEMP` to `/tmp/artifacts/ci-temp/`
- The value was decided in #105: `RAYCI_TEMP` is effectively inert, and `/tmp/artifacts/` is already volume-mounted by rayci's Go source

No other values in the file are changed.

Closes #118
Closes #105