### PR TITLE
Configure Bazel remote cache URL for Docker containers

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -44,7 +44,7 @@ runner_queues:
 
 env:
   RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"
-  BUILDKITE_BAZEL_CACHE_URL: ""
+  BUILDKITE_BAZEL_CACHE_URL: "http://rayci.localhost:9090"
   RAYCI_STAGE: "premerge"
   RAYCI_DISABLE_TEST_DB: "1"
 


### PR DESCRIPTION
## Summary

- Sets `BUILDKITE_BAZEL_CACHE_URL` to `http://rayci.localhost:9090` in `.buildkite/fork-config.yaml`, enabling the host's `bazel-remote` HTTP cache for CI builds

## Investigation findings

### Docker networking in Ray CI

Ray CI runs builds and tests inside Docker containers using the **default bridge network** (not `--network=host`). From bridge-networked containers, `127.0.0.1` refers to the container's own loopback — not the host — so the host's `bazel-remote` at `http://127.0.0.1:9090` is unreachable.

### The `rayci.localhost` mechanism

`ci/ray_ci/linux_container.py` already adds `--add-host rayci.localhost:host-gateway` to **every** Linux CI container's `docker run` command. Docker's `host-gateway` special value resolves to the host machine's IP. This means `http://rayci.localhost:9090` correctly reaches the host's `bazel-remote` from inside any runtime container.

### Two cache URL paths

| Context | URL reachable? | Why |
|---------|---------------|-----|
| `docker run` (test/build containers) | Yes | `--add-host rayci.localhost:host-gateway` resolves to host IP |
| `docker build` (Wanda image builds) | No | No `--add-host` during `docker build`; hostname doesn't resolve |

Bazel gracefully degrades when `--remote_cache` is unreachable — it logs warnings but continues without caching. So image builds will work fine, just without cache acceleration. Runtime test/build steps (the bulk of CI) will benefit from caching.

### Why `rayci.localhost` over alternatives

- `172.17.0.1` (Docker bridge gateway): Works but is fragile — depends on Docker's default bridge config
- `host.docker.internal`: Requires `--add-host` on Linux Docker Engine, not set up
- `rayci.localhost`: Already configured by Ray CI's own `linux_container.py` — the designed mechanism

## Files changed

| File | Change |
|------|--------|
| `.buildkite/fork-config.yaml` | `BUILDKITE_BAZEL_CACHE_URL: ""` → `"http://rayci.localhost:9090"` |

Closes #119