### PR TITLE
Make docker_login() fall back to existing Docker credentials

### DIFF
--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 import logging
 import sys
 from typing import List
@@ -10,6 +11,7 @@ import pytest
 from ci.ray_ci.utils import (
     chunk_into_n,
     docker_login,
+    _docker_config_has_auth,
     _ecr_docker_login,
     _ghcr_docker_login,
     filter_tests,
@@ -68,9 +70,57 @@ def test_ghcr_docker_login() -> None:
 def test_ghcr_docker_login_missing_token() -> None:
     with mock.patch.dict(
         "os.environ", {}, clear=True
+    ), mock.patch(
+        "ci.ray_ci.utils._docker_config_has_auth", return_value=False
     ):
         with pytest.raises(RuntimeError, match="GITHUB_TOKEN or GHCR_TOKEN"):
             _ghcr_docker_login("ghcr.io")
+
+
+def test_ghcr_docker_login_falls_back_to_docker_config(caplog) -> None:
+    """When no token env var is set but Docker config has auth, skip login."""
+    with mock.patch.dict(
+        "os.environ", {}, clear=True
+    ), mock.patch(
+        "ci.ray_ci.utils._docker_config_has_auth", return_value=True
+    ), caplog.at_level(logging.INFO):
+        _ghcr_docker_login("ghcr.io")  # should not raise
+    assert "already authenticated" in caplog.text
+
+
+def test_docker_config_has_auth_exact_match(tmp_path) -> None:
+    docker_dir = tmp_path / ".docker"
+    docker_dir.mkdir()
+    config = {"auths": {"ghcr.io": {"auth": "dummytoken"}}}
+    (docker_dir / "config.json").write_text(json.dumps(config))
+
+    with mock.patch("ci.ray_ci.utils.Path.home", return_value=tmp_path):
+        assert _docker_config_has_auth("ghcr.io") is True
+        assert _docker_config_has_auth("docker.io") is False
+
+
+def test_docker_config_has_auth_https_prefix(tmp_path) -> None:
+    docker_dir = tmp_path / ".docker"
+    docker_dir.mkdir()
+    config = {"auths": {"https://ghcr.io": {"auth": "dummytoken"}}}
+    (docker_dir / "config.json").write_text(json.dumps(config))
+
+    with mock.patch("ci.ray_ci.utils.Path.home", return_value=tmp_path):
+        assert _docker_config_has_auth("ghcr.io") is True
+
+
+def test_docker_config_has_auth_no_file(tmp_path) -> None:
+    with mock.patch("ci.ray_ci.utils.Path.home", return_value=tmp_path):
+        assert _docker_config_has_auth("ghcr.io") is False
+
+
+def test_docker_config_has_auth_invalid_json(tmp_path) -> None:
+    docker_dir = tmp_path / ".docker"
+    docker_dir.mkdir()
+    (docker_dir / "config.json").write_text("not valid json")
+
+    with mock.patch("ci.ray_ci.utils.Path.home", return_value=tmp_path):
+        assert _docker_config_has_auth("ghcr.io") is False
 
 
 def test_docker_login_dispatches_ecr() -> None:

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -1,11 +1,13 @@
 import base64
 import io
+import json
 import logging
 import os
 import subprocess
 import sys
 import tempfile
 from math import ceil
+from pathlib import Path
 from typing import List
 
 import ci.ray_ci.bazel_sharding as bazel_sharding
@@ -78,13 +80,36 @@ def _ecr_docker_login(docker_ecr: str) -> None:
 
 
 def _ghcr_docker_login(registry: str) -> None:
-    """Login to GHCR using GITHUB_TOKEN or GHCR_TOKEN env var."""
+    """Login to GHCR using GITHUB_TOKEN or GHCR_TOKEN env var.
+
+    Falls back to existing Docker credentials if no token env var is set.
+    """
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GHCR_TOKEN", "")
     if not token:
+        if _docker_config_has_auth(registry):
+            logger.info(
+                "No GITHUB_TOKEN/GHCR_TOKEN env var, but Docker is already "
+                "authenticated to %s — skipping login",
+                registry,
+            )
+            return
         raise RuntimeError(
             "GITHUB_TOKEN or GHCR_TOKEN env var required for GHCR auth"
         )
     _docker_login_with_token(registry, "USERNAME", token)
+
+
+def _docker_config_has_auth(registry: str) -> bool:
+    """Check if Docker config already has credentials for the given registry."""
+    config_path = Path.home() / ".docker" / "config.json"
+    if not config_path.exists():
+        return False
+    try:
+        config = json.loads(config_path.read_text())
+        auths = config.get("auths", {})
+        return registry in auths or f"https://{registry}" in auths
+    except (json.JSONDecodeError, OSError):
+        return False
 
 
 def _docker_login_with_token(registry: str, user: str, password: str) -> None:


### PR DESCRIPTION
## Summary

- Add `_docker_config_has_auth()` helper that checks `~/.docker/config.json` for existing registry credentials
- Update `_ghcr_docker_login()` to gracefully fall back to existing Docker auth instead of crashing when `GITHUB_TOKEN`/`GHCR_TOKEN` env vars are missing
- Add unit tests covering the fallback path, missing config, invalid JSON, and https-prefix matching

This unblocks `test_in_docker` and `build_in_docker` steps on Buildkite agents that already have Docker credentials configured on the host.

Closes #123