### PR TITLE
Move ci_temp outside /tmp/artifacts/ to prevent cross-step data loss

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -8,7 +8,7 @@
 ci_work_repo: "ghcr.io/294-ray-to-rust/ci"
 
 # S3/GCS path for temp files shared across build steps (required).
-ci_temp: "/tmp/artifacts/ci-temp/"
+ci_temp: "/tmp/ci-temp/"
 
 # S3 bucket for build artifacts (optional but recommended).
 artifacts_bucket: ""


### PR DESCRIPTION
## Summary

- Move `ci_temp` in `.buildkite/fork-config.yaml` from `/tmp/artifacts/ci-temp/` to `/tmp/ci-temp/`

The pre-command hook wipes `/tmp/artifacts/` before every Buildkite step, which destroys `RAYCI_TEMP` data that rayci expects to persist across steps. Moving to `/tmp/ci-temp/` keeps the temp directory on the same filesystem while surviving the cleanup.

Closes #126