### PR TITLE
Add error handling and diagnostics to pipeline.yml bootstrap step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,4 +7,27 @@
 steps:
   - label: ":pipeline: bootstrap rayci"
     commands:
-      - /usr/local/bin/rayci -upload -config .buildkite/fork-config.yaml
+      - |
+        set -euo pipefail
+
+        mkdir -p /tmp/artifacts
+
+        echo "--- :gear: Generating pipeline"
+        /usr/local/bin/rayci -output /tmp/artifacts/pipeline.yaml \
+          -config .buildkite/fork-config.yaml
+
+        STEP_COUNT=$$(grep -c "key:" /tmp/artifacts/pipeline.yaml || echo 0)
+        GROUP_COUNT=$$(grep -c "group:" /tmp/artifacts/pipeline.yaml || echo 0)
+        echo "Generated pipeline: $$STEP_COUNT steps across $$GROUP_COUNT groups"
+
+        if [ "$$STEP_COUNT" -eq 0 ]; then
+          echo "ERROR: No pipeline steps generated!"
+          exit 1
+        fi
+
+        echo "--- :buildkite: Uploading pipeline"
+        buildkite-agent pipeline upload /tmp/artifacts/pipeline.yaml
+
+        echo "Pipeline uploaded successfully ($$STEP_COUNT steps)"
+    artifact_paths:
+      - /tmp/artifacts/pipeline.yaml


### PR DESCRIPTION
## Summary

- Replace the single-command `rayci -upload` bootstrap with a diagnostic version that generates the pipeline to a file first, logs step/group counts, uploads the YAML as a Buildkite artifact, and fails explicitly if no steps are generated or upload fails.
- Uses `set -euo pipefail` so any failure in the pipeline is caught immediately.

This addresses the observed issue where builds pass in ~15 seconds with no steps uploaded, likely due to silent failures in the upload step.

Closes #128