### PR TITLE
Add canary step upload and Buildkite annotation to diagnose pipeline upload mechanism

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,9 +26,29 @@ steps:
           exit 1
         fi
 
+        echo "--- :page_facing_up: Pipeline YAML preview (first 20 lines)"
+        head -20 /tmp/artifacts/pipeline.yaml
+        echo "--- :page_facing_up: Pipeline YAML preview (last 20 lines)"
+        tail -20 /tmp/artifacts/pipeline.yaml
+
+        echo "--- :canary: Uploading canary step"
+        echo 'steps:
+          - label: ":canary: pipeline upload canary"
+            command: "echo Pipeline upload mechanism is working. Full pipeline has been uploaded."' \
+          | buildkite-agent pipeline upload
+
         echo "--- :buildkite: Uploading pipeline"
-        buildkite-agent pipeline upload /tmp/artifacts/pipeline.yaml
+        buildkite-agent pipeline upload /tmp/artifacts/pipeline.yaml 2>/tmp/artifacts/upload_stderr.txt
+        if [ -s /tmp/artifacts/upload_stderr.txt ]; then
+          echo "--- :warning: pipeline upload stderr"
+          cat /tmp/artifacts/upload_stderr.txt
+        fi
+
+        buildkite-agent annotate \
+          "Pipeline bootstrap: uploaded $$STEP_COUNT steps across $$GROUP_COUNT groups ($$(wc -l < /tmp/artifacts/pipeline.yaml) lines of YAML)" \
+          --style success --context pipeline-info
 
         echo "Pipeline uploaded successfully ($$STEP_COUNT steps)"
     artifact_paths:
       - /tmp/artifacts/pipeline.yaml
+      - /tmp/artifacts/upload_stderr.txt


### PR DESCRIPTION
## Summary

- Uploads a canary step before the full pipeline to isolate whether the upload mechanism itself works vs YAML format issues
- Creates a Buildkite annotation with step count, group count, and YAML line count for immediate UI visibility
- Logs first/last 20 lines of generated pipeline YAML in build output
- Captures and logs stderr from `buildkite-agent pipeline upload` if non-empty
- Adds `upload_stderr.txt` to artifact paths

Closes #133