### PR TITLE
Fix yq pipeline flattening bugs and add upload safety checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,9 @@ steps:
       - |
         set -euo pipefail
 
+        echo "--- :buildkite: Agent info"
+        buildkite-agent --version
+
         mkdir -p /tmp/artifacts
 
         echo "--- :gear: Generating pipeline"
@@ -44,27 +47,49 @@ steps:
           .steps = [
             .steps[] |
             if has("group") then
-              .steps[] as $$inner |
-              $$inner *
-              {"depends_on": (($$inner.depends_on // []) + (."depends_on" // []) | unique)}
+              .as $$group |
+              .steps[] |
+              . * (
+                if ((."depends_on" // []) + ($$group."depends_on" // []) | length) > 0
+                then {"depends_on": ((."depends_on" // []) + ($$group."depends_on" // []) | unique)}
+                else {}
+                end
+              )
             else
               .
             end
-          ] |
-          .steps[].depends_on |= (if length == 0 then null else . end)
+          ]
         ' /tmp/artifacts/pipeline.yaml > /tmp/artifacts/pipeline_flat.yaml
 
-        FLAT_STEP_COUNT=$$(grep -c "key:" /tmp/artifacts/pipeline_flat.yaml || echo 0)
-        echo "Flattened pipeline: $$FLAT_STEP_COUNT steps (was $$STEP_COUNT across $$GROUP_COUNT groups)"
+        echo "--- :mag: Validating flattened pipeline"
+        yq eval '.' /tmp/artifacts/pipeline_flat.yaml > /dev/null 2>&1 || {
+          echo "ERROR: Flattened YAML is not valid! Falling back to original."
+          cp /tmp/artifacts/pipeline.yaml /tmp/artifacts/pipeline_flat.yaml
+        }
+
+        ORIG_STEP_COUNT=$$(yq '.steps | length' /tmp/artifacts/pipeline.yaml)
+        FLAT_STEP_COUNT=$$(yq '.steps | length' /tmp/artifacts/pipeline_flat.yaml)
+        echo "Step counts: original=$$ORIG_STEP_COUNT, flattened=$$FLAT_STEP_COUNT"
+
+        if [ "$$FLAT_STEP_COUNT" -eq 0 ]; then
+          echo "ERROR: Flattened pipeline has 0 steps! Falling back to original."
+          cp /tmp/artifacts/pipeline.yaml /tmp/artifacts/pipeline_flat.yaml
+          FLAT_STEP_COUNT=$$ORIG_STEP_COUNT
+        fi
+
+        echo "--- :page_facing_up: Diagnostic diff (first step before/after flattening)"
+        diff <(yq '.steps[0]' /tmp/artifacts/pipeline.yaml) \
+             <(yq '.steps[0]' /tmp/artifacts/pipeline_flat.yaml) \
+             > /tmp/artifacts/flatten_diff.txt 2>&1 || true
 
         echo "--- :canary: Uploading canary step"
         echo 'steps:
           - label: ":canary: pipeline upload canary"
             command: "echo Pipeline upload mechanism is working. Full pipeline has been uploaded."' \
-          | buildkite-agent pipeline upload
+          | buildkite-agent pipeline upload --no-interpolation
 
         echo "--- :buildkite: Uploading pipeline"
-        buildkite-agent pipeline upload /tmp/artifacts/pipeline_flat.yaml 2>/tmp/artifacts/upload_stderr.txt
+        buildkite-agent pipeline upload --no-interpolation /tmp/artifacts/pipeline_flat.yaml 2>/tmp/artifacts/upload_stderr.txt
         if [ -s /tmp/artifacts/upload_stderr.txt ]; then
           echo "--- :warning: pipeline upload stderr"
           cat /tmp/artifacts/upload_stderr.txt
@@ -79,3 +104,4 @@ steps:
       - /tmp/artifacts/pipeline.yaml
       - /tmp/artifacts/pipeline_flat.yaml
       - /tmp/artifacts/upload_stderr.txt
+      - /tmp/artifacts/flatten_diff.txt


### PR DESCRIPTION
## Summary

- Fixes `depends_on: null` injection bug in yq flattening expression by replacing the post-processing `|= (if length == 0 then null else . end)` with an inline conditional that only adds `depends_on` when there are actual dependencies
- Adds fallback safety: validates flattened YAML parseability and step count (using `yq` for accurate counting), falling back to original pipeline if either check fails
- Adds `--no-interpolation` to both `buildkite-agent pipeline upload` calls so `$RAYCI_WORK_REPO` and similar env vars are resolved at step execution time, not during upload
- Logs `buildkite-agent --version` at bootstrap start for debugging
- Saves `flatten_diff.txt` (diff of first step before/after flattening) as an artifact

## Acceptance criteria

- [x] The `.steps[].depends_on |= (if length == 0 then null else . end)` line is removed
- [x] The yq expression only adds `depends_on` to flattened steps when dependencies actually exist
- [x] Flattened step count is validated; falls back to original YAML if 0
- [x] Flattened YAML is validated as parseable; falls back to original if not
- [x] `--no-interpolation` is added to both `buildkite-agent pipeline upload` calls
- [x] `buildkite-agent --version` is logged at the start
- [x] `flatten_diff.txt` is saved as an artifact
- [x] All `$` signs in new shell variables are properly escaped as `$$` for Buildkite YAML
- [x] The annotation reflects the correct (possibly fallback) step count
- [x] Existing error handling (`set -euo pipefail`, zero-step check) is preserved

Closes #137