### PR TITLE
Fix Buildkite queue mismatch: change all queues from 'default' to 'ethan-home'

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -20,24 +20,24 @@ forge_prefix: "cr.ray.io/rayproject/"
 
 # Buildkite agent queues for image-building steps.
 builder_queues:
-  builder: "default"
-  builder-arm64: "default"
-  builder-windows: "default"
+  builder: "ethan-home"
+  builder-arm64: "ethan-home"
+  builder-windows: "ethan-home"
 
 # Buildkite agent queues for test/runner steps.
-# Map rayci instance types to queue names.  Using "default" everywhere
-# until dedicated queues are provisioned (see #91).
+# Map rayci instance types to queue names. All steps target the
+# "ethan-home" self-hosted agent queue (see #129).
 runner_queues:
-  default: "default"
-  small: "default"
-  medium: "default"
-  large: "default"
-  gpu: "default"
-  gpu-large: "default"
-  g6-large: "default"
-  macos-arm64: "default"
-  medium-arm64: "default"
-  windows: "default"
+  default: "ethan-home"
+  small: "ethan-home"
+  medium: "ethan-home"
+  large: "ethan-home"
+  gpu: "ethan-home"
+  gpu-large: "ethan-home"
+  g6-large: "ethan-home"
+  macos-arm64: "ethan-home"
+  medium-arm64: "ethan-home"
+  windows: "ethan-home"
 
 env:
   RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,8 @@
 
 steps:
   - label: ":pipeline: bootstrap rayci"
+    agents:
+      queue: "ethan-home"
     env:
       RAYCI_SKIP_FLATTEN: "${RAYCI_SKIP_FLATTEN:-0}"
     commands:
@@ -93,6 +95,8 @@ steps:
         echo "--- :canary: Uploading canary step"
         echo 'steps:
           - label: ":canary: pipeline upload canary"
+            agents:
+              queue: "ethan-home"
             command: |
               echo "Canary step is executing at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
               buildkite-agent meta-data set "canary-executed" "true"
@@ -110,6 +114,8 @@ steps:
         echo "--- :mag: Uploading probe step"
         echo 'steps:
           - label: ":mag: upload verification probe"
+            agents:
+              queue: "ethan-home"
             command: |
               echo "Upload probe is executing — this step was dynamically uploaded with the full pipeline."
               buildkite-agent meta-data set "probe-executed" "true"


### PR DESCRIPTION
## Summary

- Change all `builder_queues` and `runner_queues` values in `.buildkite/fork-config.yaml` from `"default"` to `"ethan-home"`.
- Add `agents: { queue: "ethan-home" }` to the bootstrap step in `.buildkite/pipeline.yml`.
- Add `agents: { queue: "ethan-home" }` to the inline canary and probe steps in `.buildkite/pipeline.yml`.
- Update the comment in `fork-config.yaml` to reference `ethan-home` (was referencing `#91`, now references `#129`).

## Root cause

The Buildkite agent on `rayrust` is registered with `queue=ethan-home`, but all CI config targeted `queue=default`. Since the agent token is for self-hosted queues only it could not be re-registered to `default`. This is why every build has completed in ~15 seconds with no real work executed across 21+ merged PRs.

Closes #143