### PR TITLE
fix(fork-pipeline): remove broken dependencies and unreachable block from core.rayci.yml

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -1,1 +1,451 @@
-../core.rayci.yml
+group: core tests
+depends_on:
+  - forge
+  - ray-core-build
+  - ray-dashboard-build
+steps:
+  # builds
+  - name: corebuild-multipy
+    label: "wanda: corebuild-py{{matrix}}"
+    wanda: ci/docker/core.build.wanda.yaml
+    tags: cibase
+    matrix:
+      - "3.10"
+      - "3.12"
+    env:
+      PYTHON: "{{matrix}}"
+      BASE_TYPE: "build"
+      BUILD_VARIANT: "build"
+    depends_on: oss-ci-base_build-multipy
+
+  - name: coregpubuild-multipy
+    label: "wanda: coregpubuild-py{{matrix}}"
+    wanda: ci/docker/core.build.wanda.yaml
+    tags: cibase
+    depends_on: oss-ci-base_gpu-multipy
+    env:
+      PYTHON: "{{matrix}}"
+      BASE_TYPE: "gpu"
+      BUILD_VARIANT: "gpubuild"
+      RAYCI_IS_GPU_BUILD: "true"
+    matrix:
+      - "3.10"
+
+  - name: minbuild-core
+    label: "wanda: minbuild-core-py{{matrix}}"
+    wanda: ci/docker/min.build.wanda.yaml
+    depends_on: oss-ci-base_test-multipy
+    tags: cibase
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      EXTRA_DEPENDENCY: core
+
+  - wait: ~
+    depends_on:
+      - corebuild-multipy
+
+  # tests
+  - label: ":ray: core: python tests"
+    tags:
+      - python
+      - dashboard
+    instance_type: large
+    parallelism: 4
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
+        --install-mask all-ray-libraries
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+        --except-tags custom_setup
+        --install-mask all-ray-libraries
+
+  - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    tags:
+      - python
+      - dashboard
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
+        --install-mask all-ray-libraries
+        --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
+        --python-version {{matrix.python}} --build-name corebuild-py{{matrix.python}}
+        --except-tags custom_setup
+    depends_on: corebuild-multipy
+    matrix:
+      setup:
+        python: ["3.12"]
+        worker_id: ["0", "1", "2", "3"]
+
+  - label: ":ray: core: ray client tests"
+    tags:
+      - ray_client
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/...   core
+        --install-mask all-ray-libraries
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+        --only-tags ray_client
+
+  - label: ":ray: core: redis tests"
+    tags:
+      - python
+      - oss
+      - skip-on-premerge
+    instance_type: large
+    parallelism: 4
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
+        --install-mask all-ray-libraries
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --test-env=TEST_EXTERNAL_REDIS=1
+        --except-tags custom_setup
+        --python-version 3.10 --build-name corebuild-py3.10
+
+  - label: ":ray: core: memory pressure tests"
+    tags:
+      - python
+      - oss
+      - skip-on-premerge
+    instance_type: medium
+    commands:
+      - cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT
+      - (cd python/ray/dashboard/client && npm ci && npm run build)
+      - pip install -e python[client]
+      - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)
+        --test_tag_filters=mem_pressure -- //python/ray/tests/...
+    job_env: corebuild-py3.10
+
+  - label: ":ray: core: out of disk tests"
+    tags:
+      - python
+      - oss
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --python-version 3.10 --build-name corebuild-py3.10
+        --only-tags=tmpfs --tmp-filesystem=tmpfs
+
+  - label: ":ray: core: out of disk redis tests"
+    tags:
+      - python
+      - oss
+      - skip-on-premerge
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --test-env=TEST_EXTERNAL_REDIS=1
+        --only-tags=tmpfs --tmp-filesystem=tmpfs
+        --python-version 3.10 --build-name corebuild-py3.10
+
+  - label: ":ray: core: doc tests"
+    tags:
+      - python
+      - doc
+    instance_type: large
+    commands:
+      # doc tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/... //doc/... core
+        --only-tags doctest
+        --python-version 3.10 --build-name corebuild-py3.10
+        --parallelism-per-worker 3
+      # doc examples
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
+        --install-mask all-ray-libraries
+        --except-tags doctest,post_wheel_build,gpu,multi_gpu,mem_pressure
+        --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+        --skip-ray-installation
+      # doc memory pressure example
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
+        --only-tags mem_pressure
+        --except-tags gpu
+        --python-version 3.10 --build-name corebuild-py3.10
+        --skip-ray-installation
+
+  - label: ":ray: core: dashboard tests"
+    tags:
+      - python
+      - dashboard
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... core
+        --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+      # ui tests
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
+        "./python/ray/dashboard/tests/run_ui_tests.sh"
+
+  - label: ":ray: core: debug tests"
+    tags:
+      - python
+      - skip-on-premerge
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --install-mask all-ray-libraries
+        --build-type debug
+        --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+        --only-tags debug_tests
+        --except-tags kubernetes,manual
+
+  - label: ":ray: core: asan tests"
+    tags:
+      - python
+      - skip-on-premerge
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --install-mask all-ray-libraries
+        --build-type asan
+        --parallelism-per-worker 2
+        --python-version 3.10 --build-name corebuild-py3.10
+        --only-tags asan_tests
+        --except-tags kubernetes,manual
+
+  - label: ":ray: core: wheel tests"
+    key: core-wheel-tests
+    tags: linux_wheels
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core
+        --install-mask all-ray-libraries
+        --build-type wheel
+        --parallelism-per-worker 3
+        --python-version 3.10 --build-name corebuild-py3.10
+        --only-tags post_wheel_build
+        --test-env=RAY_CI_POST_WHEEL_TESTS=True
+    depends_on:
+      - manylinux-x86_64
+      - corebuild-multipy
+      - forge
+      - ray-wheel-build
+
+  - label: ":ray: core: minimal tests {{matrix}}"
+    tags:
+      - python
+      - dashboard
+      - oss
+      - min_build
+    instance_type: medium
+    commands:
+      # validate minimal installation
+      - python ./ci/env/check_minimal_install.py
+      # core tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
+        --parallelism-per-worker 3
+        --python-version {{matrix}}
+        --build-name minbuild-core-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+        --python-version {{matrix}}
+        --except-tags basic_test,manual,cgroup
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
+        --parallelism-per-worker 3
+        --python-version {{matrix}}
+        --build-name minbuild-core-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+        --except-tags no_basic_test,manual
+        --skip-ray-installation
+      # core redis tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
+        --parallelism-per-worker 3
+        --python-version {{matrix}}
+        --build-name minbuild-core-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=TEST_EXTERNAL_REDIS=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+        --except-tags no_basic_test,manual
+        --skip-ray-installation
+      # serve tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve
+        --parallelism-per-worker 3
+        --python-version {{matrix}}
+        --build-name minbuild-core-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --only-tags minimal
+        --skip-ray-installation
+    depends_on:
+      - minbuild-core
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+
+  - label: ":ray: core: cgroup tests"
+    tags:
+      - core_cpp
+      - python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //:all
+        //python/ray/tests/resource_isolation:test_resource_isolation_integration
+        //python/ray/tests/resource_isolation:test_resource_isolation_config core
+        --privileged --cache-test-results
+        --python-version 3.10 --build-name corebuild-py3.10
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/ray/common/cgroup2/tests/... core
+        --build-type clang --cache-test-results
+        --python-version 3.10 --build-name corebuild-py3.10
+      - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
+        "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
+
+  - label: ":ray: core: cpp tests"
+    tags: core_cpp
+
+    instance_type: medium
+    commands:
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker --
+        //:all //src/... core --except-tags=cgroup --build-type clang
+        --python-version 3.10 --build-name corebuild-py3.10
+        --cache-test-results --parallelism-per-worker 2
+
+  - label: ":ray: core: cpp asan tests"
+    tags: core_cpp
+    instance_type: medium
+    commands:
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
+        --build-type asan-clang --cache-test-results --parallelism-per-worker 2
+        --python-version 3.10 --build-name corebuild-py3.10
+    depends_on:
+      - corebuild-multipy
+
+  - label: ":ray: core: cpp ubsan tests"
+    tags: core_cpp
+    instance_type: large
+    commands:
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --python-version 3.10 --build-name corebuild-py3.10
+        --build-type ubsan --except-tags no_ubsan,cgroup
+        --cache-test-results --parallelism-per-worker 2
+    depends_on:
+      - corebuild-multipy
+
+  - label: ":ray: core: cpp tsan tests"
+    tags: core_cpp
+    instance_type: medium
+    commands:
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --python-version 3.10 --build-name corebuild-py3.10
+        --build-type tsan-clang --except-tags no_tsan,cgroup
+        --cache-test-results --parallelism-per-worker 2
+    depends_on:
+      - corebuild-multipy
+
+  - label: ":ray: core: flaky tests"
+    key: core_flaky_tests
+    tags:
+      - python
+      - flaky
+      - skip-on-premerge
+    instance_type: large
+    soft_fail: true
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/... //doc/... core
+        --python-version 3.10 --build-name corebuild-py3.10
+        --install-mask all-ray-libraries
+        --run-flaky-tests
+        --except-tags multi_gpu,cgroup
+    depends_on:
+      - corebuild-multipy
+
+  - label: ":ray: core: flaky gpu tests"
+    key: core_flaky_gpu_tests
+    tags:
+      - gpu
+      - python
+      - skip-on-premerge
+    instance_type: gpu-large
+    soft_fail: true
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/... //python/ray/dag/... //doc/... core
+        --install-mask all-ray-libraries
+        --run-flaky-tests
+        --gpus 4
+        --build-name coregpubuild-py3.10
+        --python-version 3.10
+        --only-tags multi_gpu
+    depends_on: coregpubuild-multipy
+
+  - label: ":ray: core: cpp worker tests"
+    tags:
+      - core_cpp
+      - cpp
+      - oss
+    instance_type: medium
+    commands:
+      - if [[ "$${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+          echo "build --remote_upload_local_results=false" >> ~/.bazelrc;
+        fi
+      # cpp worker tests has one that tests cross-language with Java.
+      - RAY_INSTALL_JAVA=1 ci/ci.sh build
+      - ci/ci.sh test_cpp
+    depends_on: oss-ci-base_build-multipy
+    job_env: oss-ci-base_build-py3.10
+
+  - label: ":ray: core: java worker tests"
+    tags:
+      - java
+      - python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --python-version 3.10 --build-name corebuild-py3.10
+        --build-type java
+        --only-tags needs_java
+    depends_on: corebuild-multipy
+
+  - label: ":core: core: spark-on-ray tests"
+    # NOTE: The Spark-on-Ray tests intentionally aren't triggered by the `java` tag to
+    # avoid running them for every C++ code change.
+    tags:
+      - spark_on_ray
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --build-type debug
+        --test-env=RAY_ON_SPARK_BACKGROUND_JOB_STARTUP_WAIT=1
+        --test-env=RAY_ON_SPARK_RAY_WORKER_NODE_STARTUP_INTERVAL=5
+        --only-tags spark_on_ray
+        --python-version 3.10 --build-name corebuild-py3.10
+    depends_on:
+      - corebuild-multipy
+
+  # block gpu tests on premerge and microcheck
+  - block: "run multi gpu tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    key: block-core-gpu-tests
+    depends_on: []
+
+  - label: ":ray: core: multi gpu tests"
+    key: core-multi-gpu-tests
+    tags:
+      - cgraphs_direct_transport
+      - gpu
+    instance_type: gpu-large
+    # we're running some cgraph doc tests here as well since they need gpus
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //doc/... core
+        --gpus 4
+        --build-name coregpubuild-py3.10
+        --python-version 3.10
+        --only-tags multi_gpu
+        --install-mask all-ray-libraries
+    depends_on:
+      - block-core-gpu-tests
+      - coregpubuild-multipy


### PR DESCRIPTION
## Summary

- Replace the `fork-pipeline/core.rayci.yml` symlink with a standalone fork-specific copy
- Remove 4 steps with unresolvable external dependencies (`databuild-multipy`, `datalbuild-multipy`, `raycpubase`)
- Remove the `block: "run cpp sanitizer tests"` step (hardcoded upstream pipeline IDs) and its `depends_on` references from 3 cpp sanitizer test steps
- GPU-related block step and GPU test steps are left unchanged

Closes #146