### PR TITLE
Fork base.rayci.yml: remove non-Tier-1-3 and structurally broken image builds

### DIFF
--- a/.buildkite/fork-pipeline/base.rayci.yml
+++ b/.buildkite/fork-pipeline/base.rayci.yml
@@ -1,1 +1,25 @@
-../base.rayci.yml
+group: base
+steps:
+  - name: oss-ci-base_test-multipy
+    label: "wanda: oss-ci-base_test-py{{matrix}}"
+    wanda: ci/docker/base.test.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+    env:
+      PYTHON: "{{matrix}}"
+
+  - name: oss-ci-base_build-multipy
+    label: "wanda: oss-ci-base_build-py{{matrix}}"
+    wanda: ci/docker/base.build.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+    env:
+      PYTHON: "{{matrix}}"
+    depends_on: oss-ci-base_test-multipy
+    tags: cibase


### PR DESCRIPTION
## Summary

- Replace the symlink `.buildkite/fork-pipeline/base.rayci.yml → ../base.rayci.yml` with a standalone fork copy
- Keep only `oss-ci-base_test-multipy` and `oss-ci-base_build-multipy` steps needed for Tier 1-3 CI
- Remove 5 steps: ARM64 test/build (structurally broken on x86_64), ML (Tier 4), GPU (no fork consumer), CUDA 12.8 (Tier 5)

This reduces the pipeline by ~10 matrix-expanded steps, eliminating ARM64 build failures and unnecessary image builds with no downstream consumers in fork-pipeline.

Closes #150