### PR TITLE
fix(pipeline): escape $(date) calls to prevent Buildkite interpolation error

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,13 +106,13 @@ steps:
 
         echo "--- :buildkite: Uploading pipeline"
         # Do NOT use --no-interpolation here. The rayci-generated YAML (from
-        # fork-pipeline/*.rayci.yml) uses Buildkite's $${ } escape syntax for
-        # variables that must resolve at step execution time (e.g.
-        # $${BUILDKITE_PARALLEL_JOB_COUNT}, $${RAYCI_WORK_REPO}). Buildkite
-        # interpolation converts $${ } → ${ } at upload time so the shell can
-        # evaluate them when the step runs. With --no-interpolation the double-
-        # dollar sequences stay literal and bash interprets $$ as the PID,
-        # producing garbage like "12345{RAYCI_WORK_REPO}".
+        # fork-pipeline/*.rayci.yml) uses Buildkite's double-dollar escape
+        # syntax for variables that must resolve at step execution time (e.g.
+        # BUILDKITE_PARALLEL_JOB_COUNT, RAYCI_WORK_REPO). Buildkite
+        # interpolation strips the extra dollar sign at upload time so the
+        # shell can evaluate them when the step runs. With --no-interpolation
+        # the double-dollar sequences stay literal and bash interprets the
+        # double-dollar as the PID, producing garbage like "12345{RAYCI_WORK_REPO}".
         # See: https://github.com/294-ray-to-rust/ray-no-fork/issues/149
         buildkite-agent pipeline upload /tmp/artifacts/pipeline_flat.yaml 2>/tmp/artifacts/upload_stderr.txt
         if [ -s /tmp/artifacts/upload_stderr.txt ]; then


### PR DESCRIPTION
## Summary

- Escape three `$(date ...)` calls in the `.buildkite/pipeline.yml` canary step to `$$(date ...)` so that `buildkite-agent pipeline upload` does not fail with an interpolation error.
- Reword shell comment (lines 108-115) to avoid `${ }` and `$${ }` patterns that also trigger Buildkite's interpolation parser.
- This was the sole blocker preventing CI builds from running (Build #108 and #109 failures).

Closes #156
Closes #158

Closes #156
Closes #158