### PR TITLE
fix: download yq to /tmp for NixOS compatibility

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,13 +108,13 @@ steps:
 
         echo "--- :buildkite: Uploading pipeline"
         # Do NOT use --no-interpolation here. The rayci-generated YAML (from
-        # fork-pipeline/*.rayci.yml) uses Buildkite's $${ } escape syntax for
-        # variables that must resolve at step execution time (e.g.
-        # $${BUILDKITE_PARALLEL_JOB_COUNT}, $${RAYCI_WORK_REPO}). Buildkite
-        # interpolation converts $${ } → ${ } at upload time so the shell can
-        # evaluate them when the step runs. With --no-interpolation the double-
-        # dollar sequences stay literal and bash interprets $$ as the PID,
-        # producing garbage like "12345{RAYCI_WORK_REPO}".
+        # fork-pipeline/*.rayci.yml) uses Buildkite's double-dollar escape
+        # syntax for variables that must resolve at step execution time (e.g.
+        # BUILDKITE_PARALLEL_JOB_COUNT, RAYCI_WORK_REPO). Buildkite
+        # interpolation strips one layer of dollar signs at upload time so the
+        # shell can evaluate them when the step runs. With --no-interpolation
+        # the double-dollar sequences stay literal and bash interprets the
+        # double-dollar as the PID, producing garbage like "12345{RAYCI_WORK_REPO}".
         # See: https://github.com/294-ray-to-rust/ray-no-fork/issues/149
         buildkite-agent pipeline upload /tmp/artifacts/pipeline_flat.yaml 2>/tmp/artifacts/upload_stderr.txt
         if [ -s /tmp/artifacts/upload_stderr.txt ]; then


### PR DESCRIPTION
## Summary

- Change yq fallback download path from `/usr/local/bin/yq` to `/tmp/yq` for NixOS compatibility
- Prepend `/tmp` to `PATH` so `yq` is found by subsequent commands
- The `if ! command -v yq` guard still skips the download when yq is already installed

Closes #162