### PR TITLE
Fix hardcoded /usr/local/bin/rayci paths to use PATH resolution

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -5,7 +5,7 @@ steps:
   - label: ":test_tube: test-rules"
     key: test-rules
     commands:
-      - /usr/local/bin/rayci test-rules
+      - rayci test-rules
     instance_type: small
     tags:
       - tools

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
         mkdir -p /tmp/artifacts
 
         echo "--- :gear: Generating pipeline"
-        /usr/local/bin/rayci -output /tmp/artifacts/pipeline.yaml \
+        rayci -output /tmp/artifacts/pipeline.yaml \
           -config .buildkite/fork-config.yaml \
           -buildkite-dir .buildkite/fork-pipeline/
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `/usr/local/bin/rayci` with bare `rayci` in `.buildkite/pipeline.yml`, `.buildkite/cicd.rayci.yml`, and `.buildkite/fork-pipeline/cicd.rayci.yml`
- NixOS installs `rayci` via Nix at a non-FHS path; the agent already has it in `PATH`, so the absolute path fails with "No such file or directory"

Closes #161