### PR TITLE
Remove hardcoded upstream pipeline IDs from fork core.rayci.yml

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -53,7 +53,7 @@ steps:
         --install-mask all-ray-libraries
 
   - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    if: build.pull_request.labels includes "continuous-build"
     tags:
       - python
       - dashboard


### PR DESCRIPTION
## Summary

- Removes hardcoded upstream Ray Buildkite pipeline IDs from the `if` condition on Python 3.12 matrix test steps in `.buildkite/fork-pipeline/core.rayci.yml`
- Keeps the `continuous-build` PR label gate so these tests can still be triggered when needed

These pipeline IDs belong to upstream Ray and never match our fork's pipeline, causing 4 `core: python 3.12 tests` steps to show as "broken" in every build.

Closes #182