### PR TITLE
Remove diagnostic canary and probe steps from bootstrap.sh

### DIFF
--- a/.buildkite/bootstrap.sh
+++ b/.buildkite/bootstrap.sh
@@ -110,18 +110,6 @@ else
   fi
 fi
 
-echo "--- :canary: Uploading canary step"
-echo 'steps:
-  - label: ":canary: pipeline upload canary"
-    agents:
-      queue: "ethan-home"
-    command: |
-      echo "Canary step is executing at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      buildkite-agent meta-data set "canary-executed" "true"
-      buildkite-agent meta-data set "canary-timestamp" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      buildkite-agent annotate "Canary step executed at $(date -u). This confirms buildkite-agent pipeline upload is working." --style success --context canary-probe' \
-  | buildkite-agent pipeline upload
-
 echo "--- :buildkite: Uploading pipeline"
 # Do NOT use --no-interpolation here. The rayci-generated YAML (from
 # fork-pipeline/*.rayci.yml) uses Buildkite's ${ } escape syntax for
@@ -135,18 +123,6 @@ if [ -s /tmp/artifacts/upload_stderr.txt ]; then
   echo "--- :warning: pipeline upload stderr"
   cat /tmp/artifacts/upload_stderr.txt
 fi
-
-echo "--- :mag: Uploading probe step"
-echo 'steps:
-  - label: ":mag: upload verification probe"
-    agents:
-      queue: "ethan-home"
-    command: |
-      echo "Upload probe is executing - this step was dynamically uploaded with the full pipeline."
-      buildkite-agent meta-data set "probe-executed" "true"
-      CANARY=$(buildkite-agent meta-data get "canary-executed" 2>/dev/null || echo "unknown")
-      buildkite-agent annotate "Upload probe executed. Canary: $CANARY. This confirms the full pipeline was uploaded and at least one step ran." --style info --context upload-probe' \
-  | buildkite-agent pipeline upload
 
 if [ "${DID_FLATTEN:-0}" = "1" ]; then
   buildkite-agent annotate \


### PR DESCRIPTION
## Summary

- Remove the `:canary: pipeline upload canary` step from `.buildkite/bootstrap.sh`
- Remove the `:mag: upload verification probe` step from `.buildkite/bootstrap.sh`
- Keep `upload_stderr.txt` and `flatten_diff.txt` artifact paths in `pipeline.yml` as they are still generated and useful for debugging real pipeline issues

These diagnostic steps were added during debugging to verify `buildkite-agent pipeline upload` was working. Now that pipeline upload is proven reliable (builds 197–199), they only add noise (~3+ seconds each) and clutter the Buildkite UI.

The main pipeline upload and the annotation showing step count are preserved.

Closes #183