### PR TITLE
Remove continuous-build-only python 3.12 test steps from fork pipeline

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -52,24 +52,6 @@ steps:
         --except-tags custom_setup
         --install-mask all-ray-libraries
 
-  - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.pull_request.labels includes "continuous-build"
-    tags:
-      - python
-      - dashboard
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
-        --install-mask all-ray-libraries
-        --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name corebuild-py{{matrix.python}}
-        --except-tags custom_setup
-    depends_on: corebuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1", "2", "3"]
-
   - label: ":ray: core: ray client tests"
     tags:
       - ray_client


### PR DESCRIPTION
## Summary

- Removes lines 55-71 from `.buildkite/fork-pipeline/core.rayci.yml` — the `continuous-build`-gated python 3.12 matrix test steps
- These steps show as "broken" in Buildkite due to interaction between `if: <false>`, `depends_on`, and `matrix.setup`
- They never actually run on the fork (no `continuous-build` label), so removing them cleans up build results with no functional change

Closes #194