### PR TITLE
Replace wait barrier in core.rayci.yml with explicit depends_on

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -33,10 +33,6 @@ steps:
       PYTHON_VERSION: "{{matrix}}"
       EXTRA_DEPENDENCY: core
 
-  - wait: ~
-    depends_on:
-      - corebuild-multipy
-
   # tests
   - label: ":ray: core: python tests"
     tags:
@@ -50,7 +46,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --python-version 3.10 --build-name corebuild-py3.10
         --except-tags custom_setup
-        --install-mask all-ray-libraries
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
     if: build.pull_request.labels includes "continuous-build"
@@ -80,6 +76,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags ray_client
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: redis tests"
     tags:
@@ -95,6 +92,7 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags custom_setup
         --python-version 3.10 --build-name corebuild-py3.10
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: memory pressure tests"
     tags:
@@ -109,6 +107,7 @@ steps:
       - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)
         --test_tag_filters=mem_pressure -- //python/ray/tests/...
     job_env: corebuild-py3.10
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: out of disk tests"
     tags:
@@ -119,6 +118,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags=tmpfs --tmp-filesystem=tmpfs
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: out of disk redis tests"
     tags:
@@ -131,6 +131,7 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --only-tags=tmpfs --tmp-filesystem=tmpfs
         --python-version 3.10 --build-name corebuild-py3.10
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: doc tests"
     tags:
@@ -156,6 +157,7 @@ steps:
         --except-tags gpu
         --python-version 3.10 --build-name corebuild-py3.10
         --skip-ray-installation
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: dashboard tests"
     tags:
@@ -170,6 +172,7 @@ steps:
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./python/ray/dashboard/tests/run_ui_tests.sh"
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: debug tests"
     tags:
@@ -184,6 +187,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags debug_tests
         --except-tags kubernetes,manual
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: asan tests"
     tags:
@@ -198,6 +202,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags asan_tests
         --except-tags kubernetes,manual
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: wheel tests"
     key: core-wheel-tests
@@ -291,6 +296,7 @@ steps:
       - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
         "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: cpp tests"
     tags: core_cpp
@@ -301,6 +307,7 @@ steps:
         //:all //src/... core --except-tags=cgroup --build-type clang
         --python-version 3.10 --build-name corebuild-py3.10
         --cache-test-results --parallelism-per-worker 2
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: cpp asan tests"
     tags: core_cpp


### PR DESCRIPTION
## Summary

- Remove the `wait: ~` step (lines 36-38) that becomes a global pipeline barrier after yq flattening, blocking lint and dependency steps unnecessarily
- Add explicit `depends_on: corebuild-multipy` to all 12 core test steps that relied on the wait barrier
- Remove duplicate `--install-mask all-ray-libraries` on the python tests step

## Why

After `bootstrap.sh` flattens groups with yq, the `wait` step becomes top-level and blocks ALL subsequent pipeline steps (lint, dependencies) until every preceding step completes. With explicit `depends_on`, each core test step waits only for `corebuild-multipy`, and lint/dependency steps can start as soon as forge is ready.

Closes #198