### PR TITLE
Add GHCR_TOKEN and GITHUB_TOKEN to Docker env passthrough

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -44,6 +44,8 @@ env:
   BUILDKITE_BAZEL_CACHE_URL: "http://rayci.localhost:9090"
   RAYCI_STAGE: "premerge"
   RAYCI_DISABLE_TEST_DB: "1"
+  GHCR_TOKEN: ""
+  GITHUB_TOKEN: ""
 
 # Tags that cause steps to be unconditionally skipped.
 skip_tags:


### PR DESCRIPTION
## Summary

- Add `GHCR_TOKEN: ""` and `GITHUB_TOKEN: ""` to `.buildkite/fork-config.yaml` env section so rayci includes them in Docker plugin `--env` passthrough
- This unblocks all 20+ `test_in_docker` and `build_in_docker` steps that fail with `RuntimeError: GITHUB_TOKEN or GHCR_TOKEN env var required for GHCR auth`

## How it works

The pre-command hook already exports `GHCR_TOKEN` on the agent. By listing the var in `fork-config.yaml`'s env section (same pattern as `RAYCI_DISABLE_TEST_DB`), rayci adds `--env GHCR_TOKEN` to Docker run commands, propagating the real token into containers.

Empty-string defaults are safe: if the hook doesn't set the token, `os.environ.get("GHCR_TOKEN", "")` returns falsy `""`, and the existing fallback logic in `_ghcr_docker_login()` applies.

Closes #200