### PR TITLE
Remove test-rules step from cicd pipeline

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -2,14 +2,6 @@ group: reef tests
 depends_on:
   - forge
 steps:
-  - label: ":test_tube: test-rules"
-    key: test-rules
-    commands:
-      - rayci test-rules
-    instance_type: small
-    tags:
-      - tools
-      - always
   - label: ":coral: reef: ci+release tooling tests"
     key: reef-tests
     commands:


### PR DESCRIPTION
## Summary

- Remove the `test-rules` step from `.buildkite/cicd.rayci.yml` that fails with `rayci: command not found` (exit code 127) because the `rayci` binary is not available inside the forge Docker container
- The step is informational only — no other step depends on it, and pipeline generation already applies test rules

Closes #201