### PR TITLE
Fix root-owned file cleanup in post-command hook to prevent cascading checkout failures

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -31,3 +31,12 @@ fi
 # inside another test container
 rm -rf /tmp/bazel_event_logs
 rm -rf /tmp/artifacts/test-summaries
+
+# Fix file ownership after Docker-plugin steps.
+# Docker containers create files as root inside mounted checkout volumes.
+# The Buildkite agent (non-root on NixOS) can't clean these up, breaking
+# git operations for all subsequent steps. See build 228 for evidence.
+if [[ "${OSTYPE}" == linux* ]] && [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]]; then
+  docker run --rm -v "${BUILDKITE_BUILD_CHECKOUT_PATH}:/work" alpine:latest \
+    chown -R "$(id -u):$(id -g)" /work 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary

- Adds a Docker-based `chown -R` block at the end of `.buildkite/hooks/post-command` to fix file ownership after Docker-plugin steps
- Prevents cascading checkout failures where ALL subsequent steps fail with `permission denied` errors after a Docker step creates root-owned files
- Uses the same `docker run alpine` pattern already established in the same file (line 26)

## Details

Docker-plugin steps run containers as root that create root-owned files (e.g. `python/ray.egg-info/not-zip-safe`) in the mounted checkout directory. The Buildkite agent (UID 993 on NixOS) cannot clean these up, causing every subsequent Docker-plugin step to fail at git checkout. Build 228 showed 10+ steps failing this way.

The fix runs `chown -R $(id -u):$(id -g)` via an Alpine container after each step completes, only on Linux, with `|| true` to never break a step.

Closes #204