### PR TITLE
Add hook_env_keys and docker_plugin to fork-config.yaml

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -47,6 +47,12 @@ env:
   GHCR_TOKEN: ""
   GITHUB_TOKEN: ""
 
+hook_env_keys:
+  - RAYCI_CHECKOUT_DIR
+
+docker_plugin:
+  allow_mount_buildkite_agent: true
+
 # Tags that cause steps to be unconditionally skipped.
 skip_tags:
   - disabled


### PR DESCRIPTION
## Summary

- Add `hook_env_keys: [RAYCI_CHECKOUT_DIR]` to fork-config.yaml so the pre-command hook's checkout directory env var is passed through to Docker containers, enabling `test_in_docker` volume mounts
- Add `docker_plugin: { allow_mount_buildkite_agent: true }` to match all upstream Ray CI configs

Both settings are present in all three upstream configs (release, bisect, cicd-cron) and are required for `test_in_docker` steps to function correctly.

Closes #205