### PR TITLE
Fix UID mismatch: make checkout writable and git-safe for Docker containers

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -46,6 +46,11 @@ env:
   RAYCI_DISABLE_TEST_DB: "1"
   GHCR_TOKEN: ""
   GITHUB_TOKEN: ""
+  # Fix git "dubious ownership" error inside Docker containers.
+  # Container user (forge, UID 2000) differs from checkout owner (UID 993).
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: "safe.directory"
+  GIT_CONFIG_VALUE_0: "*"
 
 hook_env_keys:
   - RAYCI_CHECKOUT_DIR

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -34,5 +34,12 @@ elif [[ "${OSTYPE}" == msys ]]; then
 fi
 
 
+# Make checkout writable by Docker container users (UID mismatch: host=993, forge=2000).
+# The post-command hook restores ownership via chown after each step.
+if [[ "${OSTYPE}" == linux* ]] && [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]]; then
+  docker run --rm -v "${BUILDKITE_BUILD_CHECKOUT_PATH}:/work" alpine:latest \
+    chmod -R a+rwX /work 2>/dev/null || true
+fi
+
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR


### PR DESCRIPTION
## Summary

- Add `chmod -R a+rwX` in the pre-command hook so Docker container users (forge, UID 2000) can write to the checkout directory owned by the Buildkite agent (UID 993)
- Add `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` env vars to `fork-config.yaml` to fix git "dubious ownership" errors inside containers

## Details

All 7 failing lint/dependency steps in build 243 share a single root cause: UID mismatch between the Buildkite agent (993) and the Docker container user forge (2000).

**Part 1 (pre-command hook):** Runs `chmod -R a+rwX` on the checkout after git operations but before Docker plugin commands. This fixes write permission errors in `doc_readme`, `dashboard_format`, and `raydepsets_compile`. The existing post-command hook already restores ownership via `chown`.

**Part 2 (fork-config.yaml):** Sets git config environment variables so git accepts the directory despite ownership mismatch. This fixes "dubious ownership" errors in `clang_format`, `pre_commit`, `semgrep_lint`, and `pydoclint`.

Closes #210