### PR TITLE
Fix GHCR authentication for test_in_docker inside forge containers

### DIFF
--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -53,7 +53,6 @@ class LinuxContainer(Container):
         build_cmd = [
             "docker",
             "build",
-            "--pull",
             "--progress=plain",
             "-t",
             self._get_docker_image(),

--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -67,14 +67,15 @@ def test_ghcr_docker_login() -> None:
         _ghcr_docker_login("ghcr.io")
 
 
-def test_ghcr_docker_login_missing_token() -> None:
+def test_ghcr_docker_login_missing_token(caplog) -> None:
+    """When no token and no Docker config, log warning and return gracefully."""
     with mock.patch.dict(
         "os.environ", {}, clear=True
     ), mock.patch(
         "ci.ray_ci.utils._docker_config_has_auth", return_value=False
-    ):
-        with pytest.raises(RuntimeError, match="GITHUB_TOKEN or GHCR_TOKEN"):
-            _ghcr_docker_login("ghcr.io")
+    ), caplog.at_level(logging.WARNING):
+        _ghcr_docker_login("ghcr.io")  # should not raise
+    assert "Proceeding without auth" in caplog.text
 
 
 def test_ghcr_docker_login_falls_back_to_docker_config(caplog) -> None:

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -93,9 +93,12 @@ def _ghcr_docker_login(registry: str) -> None:
                 registry,
             )
             return
-        raise RuntimeError(
-            "GITHUB_TOKEN or GHCR_TOKEN env var required for GHCR auth"
+        logger.warning(
+            "No GITHUB_TOKEN/GHCR_TOKEN and no Docker config for %s. "
+            "Proceeding without auth (images must be locally cached).",
+            registry,
         )
+        return
     _docker_login_with_token(registry, "USERNAME", token)
 
 


### PR DESCRIPTION
## Summary

- Make `_ghcr_docker_login()` log a warning instead of raising `RuntimeError` when no `GITHUB_TOKEN`/`GHCR_TOKEN` is available, allowing test steps to proceed with locally cached images
- Remove `--pull` flag from `install_ray()` in `LinuxContainer` so `docker build` uses Wanda-built images from the local daemon instead of forcing a GHCR pull
- Update test to verify the new graceful behavior

Closes #216