### PR TITLE
Fix RAYCI_CHECKOUT_DIR not propagated to Docker plugin containers

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -40,6 +40,7 @@ runner_queues:
   windows: "ethan-home"
 
 env:
+  RAYCI_CHECKOUT_DIR: "set-by-pre-command-hook"
   RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"
   BUILDKITE_BAZEL_CACHE_URL: "http://rayci.localhost:9090"
   RAYCI_STAGE: "premerge"


### PR DESCRIPTION
## Summary

- Add `RAYCI_CHECKOUT_DIR: "set-by-pre-command-hook"` to the `env:` section of `.buildkite/fork-config.yaml`
- This ensures rayci includes `RAYCI_CHECKOUT_DIR` in the Docker plugin's `environment:` passthrough list, fixing `test_in_docker` steps that fail because the checkout directory is not mounted correctly

## How it works

1. rayci generates pipeline with `RAYCI_CHECKOUT_DIR` in the Docker plugin environment list (non-empty env values are included)
2. The pre-command hook overrides the placeholder with the actual host checkout path (`$(pwd)`)
3. Docker plugin passes the real path to forge containers
4. `test_in_docker` uses the correct host path for volume mounts instead of `None:/ray-mount`

Closes #221