### PR TITLE
Fix test_linux_tester_container tests broken by --pull removal

### DIFF
--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -170,7 +170,6 @@ def test_ray_installation() -> None:
         assert install_ray_cmds[-1] == [
             "docker",
             "build",
-            "--pull",
             "--progress=plain",
             "-t",
             docker_image,
@@ -196,10 +195,9 @@ def test_ray_installation_wheel() -> None:
         LinuxTesterContainer("team", build_type="wheel", python_version="3.10")
         docker_image = f"{_DOCKER_WORK_REPO}:team"
         cmd = install_ray_cmds[-1]
-        assert cmd[0:6] == [
+        assert cmd[0:5] == [
             "docker",
             "build",
-            "--pull",
             "--progress=plain",
             "-t",
             docker_image,


### PR DESCRIPTION
## Summary

- Remove `--pull` from expected docker build commands in `test_ray_installation` and `test_ray_installation_wheel` to match the source change made in PR #218 (`d6d929a6c2`)
- Adjust slice index `cmd[0:6]` → `cmd[0:5]` in `test_ray_installation_wheel` accordingly

Closes #223