### PR TITLE
Fix Bazel remote cache unreachable inside Docker containers

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -57,6 +57,8 @@ hook_env_keys:
 
 docker_plugin:
   allow_mount_buildkite_agent: true
+  add-host:
+    - "rayci.localhost:host-gateway"
 
 # Tags that cause steps to be unconditionally skipped.
 skip_tags:


### PR DESCRIPTION
## Summary

- Adds `add-host: ["rayci.localhost:host-gateway"]` to the `docker_plugin` section in `.buildkite/fork-config.yaml`
- This maps `rayci.localhost` to the host's gateway IP inside Docker containers, fixing the `Connection refused: /127.0.0.1:9090` errors

## Context

The Bazel remote cache URL `http://rayci.localhost:9090` resolves to `127.0.0.1` (per RFC 6761). On the host this works fine, but inside Docker containers `127.0.0.1` is the container's own loopback — not the host. Docker's `host-gateway` special value (Docker 20.10+) maps to the host machine's gateway IP.

Note: `ci/ray_ci/linux_container.py` already passes `--add-host rayci.localhost:host-gateway` for direct `docker run` commands (line 108-109). This PR adds the equivalent for steps using the Docker Buildkite plugin.

Closes #224