### PR TITLE
Fix test_worker_thread_count assertion for Python 3.13

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -268,7 +268,7 @@ def test_worker_thread_count(monkeypatch, shutdown_only):
         ray.get(actor.get_thread_count.remote())
     # Lowering these numbers in this assert should be celebrated,
     # increasing these numbers should be scrutinized
-    assert ray.get(actor.get_thread_count.remote()) in {21, 22, 23}
+    assert ray.get(actor.get_thread_count.remote()) in {20, 21, 22, 23}
 
 
 # https://github.com/ray-project/ray/issues/7287


### PR DESCRIPTION
## Summary

- Add `20` to the expected thread count set in `test_worker_thread_count` to fix deterministic failure on Python 3.13
- Python 3.13 has one fewer background thread in Ray actor workers (20 vs 21-23)
- The test's own comment says "lowering these numbers should be celebrated"

Closes #228