### PR TITLE
Fix test_autoscaler_aws Bazel timeout: size=small → medium

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -1116,12 +1116,12 @@ py_test(
 #    py_test_module_list should support subdirectories.
 py_test(
     name = "test_autoscaler_aws",
-    size = "small",
+    size = "medium",
     srcs = ["aws/test_autoscaler_aws.py"],
     tags = [
         "exclusive",
         "no_windows",
-        "small_size_python_tests",
+        "medium_size_python_tests",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
## Summary

- Bumps `test_autoscaler_aws` Bazel test size from `small` (60s) to `medium` (300s) to accommodate 60+ parametrized tests that deterministically time out at ~32% completion.
- Updates the tag from `small_size_python_tests` to `medium_size_python_tests` to match.

Closes #231