### PR TITLE
Skip test_memory_profile_dashboard_and_agent in Docker-in-Docker

### DIFF
--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -144,6 +144,10 @@ def test_memory_profiler_command_builder(monkeypatch, tmp_path):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="memray not supported in win32")
 @pytest.mark.skipif(sys.platform == "darwin", reason="memray not supported in Darwin")
+@pytest.mark.skipif(
+    os.path.exists("/.dockerenv"),
+    reason="memray profiling incompatible with Docker-in-Docker seccomp restrictions",
+)
 def test_memory_profile_dashboard_and_agent(monkeypatch, shutdown_only):
     with monkeypatch.context() as m:
         m.setenv(services.RAY_MEMRAY_PROFILE_COMPONENT_ENV, "dashboard,dashboard_agent")


### PR DESCRIPTION
## Summary

- Skip `test_memory_profile_dashboard_and_agent` when running inside Docker (detected via `/.dockerenv`), fixing the deterministic hang in the `core: python tests [g4_s2]` shard
- memray's preloaded C library needs syscalls blocked by Docker's default seccomp profile in DinD, causing the dashboard to never initialize and `ray.init()` to hang for 60s
- Consistent with existing `skipif` markers on the same test for win32/darwin

Closes #232