### PR TITLE
Fix doc_code_ray_oom_prevention OOM test thresholds for high-baseline-memory nodes

### DIFF
--- a/doc/source/ray-core/doc_code/ray_oom_prevention.py
+++ b/doc/source/ray-core/doc_code/ray_oom_prevention.py
@@ -3,7 +3,7 @@ import ray
 
 ray.init(
     _system_config={
-        "memory_usage_threshold": 0.4,
+        "memory_usage_threshold": 0.55,
     },
 )
 # fmt: off
@@ -67,8 +67,10 @@ second_actor = MemoryHogger.options(
     max_restarts=0, max_task_retries=0, name="second_actor"
 ).remote()
 
-# each task requests 0.3 of the system memory when the memory threshold is 0.4.
-allocate_bytes = get_additional_bytes_to_reach_memory_usage_pct(0.3)
+# each task requests 0.4 of the system memory when the memory threshold is 0.55.
+# Two actors combined (~0.8 of total minus baseline) will exceed the 0.55 threshold,
+# but one actor alone (~0.4 minus baseline) will stay safely below it.
+allocate_bytes = get_additional_bytes_to_reach_memory_usage_pct(0.4)
 
 first_actor_task = first_actor.allocate.remote(allocate_bytes)
 second_actor_task = second_actor.allocate.remote(allocate_bytes)


### PR DESCRIPTION
## Summary

- Raises `memory_usage_threshold` from 0.4 to 0.55 and per-actor allocation target from 0.3 to 0.4 in `doc/source/ray-core/doc_code/ray_oom_prevention.py`
- Gives ~6% margin above threshold for combined two-actor allocation and ~15% margin below threshold for single-actor allocation, replacing the previous ~1.4% margin that caused deterministic failures on ~49 GB / ~9 GB baseline nodes

## Math

On a 49 GB node with 9 GB baseline:
- **Threshold**: 55% × 49 GB ≈ 27 GB
- **Each actor allocates**: 0.4 × 49 − 9 ≈ 10.6 GB
- **Combined peak**: 9 + 2 × 10.6 = 30.2 GB (61.6%) → exceeds 55% threshold ✓
- **After killing retriable actor**: 9 + 10.6 = 19.6 GB (40%) → safely below 55% threshold ✓

Closes #233