### PR TITLE
Fix tester_container.py crash on missing bazel log dir — tests pass but step fails

### DIFF
--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -211,7 +211,7 @@ class TesterContainer(Container):
         return list(tests.values())
 
     def _cleanup_bazel_log_mount(self, bazel_log_dir: str) -> None:
-        shutil.rmtree(bazel_log_dir)
+        shutil.rmtree(bazel_log_dir, ignore_errors=True)
 
     def _run_tests_in_docker(
         self,


### PR DESCRIPTION
## Summary

- Add `ignore_errors=True` to `shutil.rmtree` in `_cleanup_bazel_log_mount` so concurrent Buildkite agent cleanup of `/tmp/artifacts` doesn't cause `FileNotFoundError` and false step failures.

Closes #239