### PR TITLE
Fix vale documentation_style lint: install docutils for RST parsing

### DIFF
--- a/ci/lint/check-documentation-style.sh
+++ b/ci/lint/check-documentation-style.sh
@@ -2,6 +2,9 @@
 
 set -euxo pipefail
 
+# Vale's RST parser requires rst2html from docutils
+pip install docutils
+
 VALE_BIN=$(mktemp -d)
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     wget https://github.com/errata-ai/vale/releases/download/v3.4.1/vale_3.4.1_Linux_64-bit.tar.gz -P "$VALE_BIN"


### PR DESCRIPTION
## Summary

- Install `docutils` (provides `rst2html`) in `ci/lint/check-documentation-style.sh` before running vale
- Vale v3.4.1's RST parser requires `rst2html` to process `.rst` files; without it, vale fails with `E100 [lintRST] Runtime error`

## Root Cause

The forge container doesn't include Python's `docutils` package. Vale shells out to `rst2html` to convert RST to HTML before linting. When `rst2html` is missing, vale reports `E100 [lintRST] Runtime error` and exits with code 2.

## Fix

A single `pip install docutils` before the vale invocation. This is the minimal change needed — no version pin changes, no RST content changes, no pipeline config changes.

Closes #241