### PR TITLE
Fix: remove root-owned python/ray.egg-info in CI post-command hook

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -33,10 +33,10 @@ rm -rf /tmp/bazel_event_logs
 rm -rf /tmp/artifacts/test-summaries
 
 # Remove build artifacts that Docker creates as root.
-# These block the agent's git checkout on subsequent builds (see builds 75-80).
+# These block the agent's git checkout on subsequent builds (see builds 75-80, 178).
 if [[ "${OSTYPE}" == linux* ]] && [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]]; then
   docker run --rm -v "${BUILDKITE_BUILD_CHECKOUT_PATH}:/work" alpine:latest \
-    rm -rf /work/python/ray.egg-info 2>/dev/null || true
+    sh -c "rm -rf /work/python/ray.egg-info /work/python/build" 2>/dev/null || true
 fi
 
 # Fix file ownership after Docker-plugin steps.


### PR DESCRIPTION
## Summary

- Add explicit `docker run ... rm -rf` for `python/ray.egg-info/` and `python/build/` in `.buildkite/hooks/post-command`, before the existing `chown -R` step
- Prevents checkout failures caused by root-owned build artifacts persisting between builds (observed in builds 75-80 and 178)
- The cleanup is idempotent: no error if the directories don't exist, no impact on test results

Closes #250