### PR TITLE
Double Bazel small-test timeout in CI to fix 25+ systemic timeouts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -160,6 +160,7 @@ aquery:ci --noshow_progress
 
 test:ci-base --test_output=errors
 test:ci-base --test_verbose_timeout_warnings
+test:ci-base --test_timeout=120,300,900,3600
 test:ci-base --flaky_test_attempts=3
 
 # Sending in PATH is required for tests to run on CI, after we enable


### PR DESCRIPTION
## Summary

- Adds `test:ci-base --test_timeout=120,300,900,3600` to `.bazelrc`, doubling the `size = "small"` test timeout from 60s to 120s in CI
- Fixes all 25+ TIMEOUT failures from build 82 with a single line change
- Only affects CI runs (`--config=ci`), not local developer builds

Closes #254