### PR TITLE
Increase Docker --shm-size from 2.5gb to 10gb to fix OOM failures

### DIFF
--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -123,7 +123,7 @@ class LinuxContainer(Container):
         extra_args += [
             "--workdir",
             "/rayci",
-            "--shm-size=2.5gb",
+            "--shm-size=10gb",
         ]
         return extra_args
 


### PR DESCRIPTION
## Summary

- Increases `--shm-size` from 2.5gb to 10gb in `ci/ray_ci/linux_container.py` to meet Ray's requirement that `/dev/shm` be at least 30% of available RAM
- Fixes `test_actor` OOM failures and eliminates `/dev/shm` fallback warnings across all tests

Closes #255