### PR TITLE
Mount Bazel repository cache into CI Docker builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -176,6 +176,7 @@ test:ci-base --test_env=PATH
 
 build:ci --color=yes
 build:ci --curses=no
+build:ci --repository_cache=/bazel-repo-cache
 build:ci --keep_going
 build:ci --progress_report_interval=100
 build:ci --show_progress_rate_limit=15

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -208,7 +208,7 @@ steps:
         --parallelism-per-worker 3
         --python-version 3.10 --build-name corebuild-py3.10
       # ui tests
-      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --volume /scratch/bazel-repo-cache:/bazel-repo-cache --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./python/ray/dashboard/tests/run_ui_tests.sh"
 
@@ -329,7 +329,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/ray/common/cgroup2/tests/... core
         --build-type clang --cache-test-results
         --python-version 3.10 --build-name corebuild-py3.10
-      - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+      - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --volume /scratch/bazel-repo-cache:/bazel-repo-cache --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
         "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
 

--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -163,7 +163,7 @@ steps:
         --parallelism-per-worker 3
         --python-version 3.10 --build-name corebuild-py3.10
       # ui tests
-      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --volume /scratch/bazel-repo-cache:/bazel-repo-cache --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./python/ray/dashboard/tests/run_ui_tests.sh"
     depends_on:
@@ -294,7 +294,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/ray/common/cgroup2/tests/... core
         --build-type clang --cache-test-results
         --python-version 3.10 --build-name corebuild-py3.10
-      - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+      - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --volume /scratch/bazel-repo-cache:/bazel-repo-cache --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
         "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
     depends_on:

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -34,7 +34,7 @@ steps:
       # Java tests need the C++ API for multi-langauge worker tests.
       - bazel run //ci/ray_ci:test_in_docker -- //... core --build-type multi-lang --build-only
         --python-version 3.10 --build-name corebuild-py3.10
-      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --volume /scratch/bazel-repo-cache:/bazel-repo-cache --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./java/test.sh"
     depends_on: corebuild-multipy

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -114,15 +114,18 @@ if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
     echo "Using local disk cache on mac"
     echo "build --disk_cache=/tmp/bazel-cache" >> ~/.bazelrc
     echo "build --repository_cache=/tmp/bazel-repo-cache" >> ~/.bazelrc
-  elif [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
-    if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
-      echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
-      if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-        echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+  elif [[ "${platform}" == linux ]]; then
+    echo "build --repository_cache=/bazel-repo-cache" >> ~/.bazelrc
+    if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
+      if [[ "${BUILDKITE_BAZEL_CACHE_URL}" == http://* ]] || [[ "${BUILDKITE_BAZEL_CACHE_URL}" == https://* ]]; then
+        echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
+        if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+          echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+        fi
+      else
+        echo "Using local disk cache at ${BUILDKITE_BAZEL_CACHE_URL}"
+        echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
       fi
-    else
-      echo "Using local disk cache at ${BUILDKITE_BAZEL_CACHE_URL}"
-      echo "build --disk_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
     fi
   fi
 fi

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -14,7 +14,10 @@ class BuilderContainer(LinuxContainer):
     ) -> None:
         super().__init__(
             f"manylinux-{architecture}",
-            volumes=[f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci"],
+            volumes=[
+                f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci",
+                "/scratch/bazel-repo-cache:/bazel-repo-cache",
+            ],
         )
         python_version_info = PYTHON_VERSIONS.get(python_version)
         assert build_type in BUILD_TYPES, f"build_type must be one of {BUILD_TYPES}"

--- a/ci/ray_ci/linux_tester_container.py
+++ b/ci/ray_ci/linux_tester_container.py
@@ -28,6 +28,7 @@ class LinuxTesterContainer(TesterContainer, LinuxContainer):
             volumes=[
                 f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/ray-mount",
                 "/var/run/docker.sock:/var/run/docker.sock",
+                "/scratch/bazel-repo-cache:/bazel-repo-cache",
             ],
             python_version=python_version,
             tmp_filesystem=tmp_filesystem,

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -101,6 +101,7 @@ def test_run_tests_in_docker() -> None:
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert "--volume /tmp:/tmp/bazel_event_logs" in input_str
+        assert "--volume /scratch/bazel-repo-cache:/bazel-repo-cache" in input_str
         assert (
             "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "
             "--config=ci-debug --test_env v=k --test_arg flag t1 t2" in input_str


### PR DESCRIPTION
## Summary

Closes #248

- Mounts `/scratch/bazel-repo-cache` from the Buildkite host into Docker containers as `/bazel-repo-cache`, enabling Bazel's `--repository_cache` to persist external dependency downloads (gRPC, protobuf, boringssl, LLVM, etc.) across builds
- Adds `build:ci --repository_cache=/bazel-repo-cache` to `.bazelrc` so all CI Bazel invocations use the cache
- Adds the volume mount to `LinuxTesterContainer`, `BuilderContainer`, and ad-hoc `docker run` commands in `.buildkite/*.rayci.yml`
- Closes the Linux gap in `ci/env/install-bazel.sh` — macOS already had `--repository_cache` configured but Linux did not

## Expected impact

- **~700MB fewer downloads per build step** (external deps are content-addressed and cached on disk)
- **10-20 minutes saved per pipeline** across all Bazel-invoking steps
- Falls back gracefully if cache dir is empty (cold start just populates it)
- Concurrent builds are safe (Bazel repository cache is content-addressed by hash)

## What's NOT changed

- Build Dockerfiles (`ray-core.Dockerfile`, etc.) already use `--repository_cache` with BuildKit cache mounts during `docker build` — this PR addresses the gap in `docker run` containers (test and build runners)
- The remote action cache (`bazel-remote` on port 9090) is unaffected — repository cache and action cache serve different purposes