### PR TITLE
Wire CI Docker builds to use local APT caching proxy

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -2,6 +2,11 @@
 
 FROM ubuntu:22.04
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN <<EOF

--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -2,6 +2,11 @@
 
 FROM ubuntu:22.04
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN <<EOF

--- a/ci/docker/base.build.Dockerfile
+++ b/ci/docker/base.build.Dockerfile
@@ -1,6 +1,11 @@
 ARG DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test
 FROM $DOCKER_IMAGE_BASE_TEST
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG RAYCI_DISABLE_JAVA=false
 
 COPY . .

--- a/ci/docker/base.build.aarch64.wanda.yaml
+++ b/ci/docker/base.build.aarch64.wanda.yaml
@@ -11,6 +11,7 @@ srcs:
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test-aarch64
   - RAYCI_DISABLE_JAVA
 tags:

--- a/ci/docker/base.build.wanda.yaml
+++ b/ci/docker/base.build.wanda.yaml
@@ -11,6 +11,7 @@ srcs:
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON
   - RAYCI_DISABLE_JAVA
 tags:

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - ci/env/install-miniforge.sh
   - ci/suppress_output
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
   - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -2,6 +2,11 @@
 ARG BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04
 FROM $BASE_IMAGE
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG PYTHON=3.10
 

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - ci/env/install-miniforge.sh
   - ci/suppress_output
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
 tags:

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -2,6 +2,11 @@
 
 FROM ubuntu:focal
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG PYTHON=3.10
 

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -7,6 +7,7 @@ srcs:
   - ci/suppress_output
   - .bazelversion
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON=3.10
 tags:

--- a/ci/docker/base.test.wanda.yaml
+++ b/ci/docker/base.test.wanda.yaml
@@ -7,6 +7,7 @@ srcs:
   - ci/suppress_output
   - .bazelversion
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
 tags:

--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -3,6 +3,11 @@
 ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py3.10
 FROM $DOCKER_IMAGE_BASE_BUILD
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG ARROW_VERSION=23.*
 ARG ARROW_MONGO_VERSION=
 ARG RAY_CI_JAVA_BUILD=

--- a/ci/docker/data.build.wanda.yaml
+++ b/ci/docker/data.build.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
   - ARROW_VERSION=23.*
 tags:

--- a/ci/docker/data9.build.wanda.yaml
+++ b/ci/docker/data9.build.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
   - ARROW_VERSION=9.*
 tags:

--- a/ci/docker/datal.build.wanda.yaml
+++ b/ci/docker/datal.build.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
   - ARROW_VERSION=23.*
 tags:

--- a/ci/docker/datamongo.build.wanda.yaml
+++ b/ci/docker/datamongo.build.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
+  - APT_PROXY
   - ARROW_VERSION=9.*
   - ARROW_MONGO_VERSION=0.5.*
   - RAY_CI_JAVA_BUILD=1

--- a/ci/docker/datan.build.wanda.yaml
+++ b/ci/docker/datan.build.wanda.yaml
@@ -10,6 +10,7 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
   - ARROW_VERSION=nightly
 tags:

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -2,6 +2,11 @@
 
 FROM ubuntu:22.04
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG BUILDKITE_BAZEL_CACHE_URL
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ci/docker/forge.aarch64.wanda.yaml
+++ b/ci/docker/forge.aarch64.wanda.yaml
@@ -2,6 +2,7 @@ name: "forge-aarch64"
 froms:
   - ubuntu:22.04
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -2,6 +2,7 @@ name: "forge"
 froms:
   - ubuntu:22.04
 build_args:
+  - APT_PROXY
   - BUILDKITE_BAZEL_CACHE_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:

--- a/ci/docker/runtime_env_container/Dockerfile
+++ b/ci/docker/runtime_env_container/Dockerfile
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 COPY python/ray/tests/runtime_env_container/ /home/ray/tests/
 
 # Install podman

--- a/ci/docker/serve.build.Dockerfile
+++ b/ci/docker/serve.build.Dockerfile
@@ -3,6 +3,11 @@
 ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build-py3.10
 FROM $DOCKER_IMAGE_BASE_BUILD AS haproxy-builder
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 RUN <<EOF
 #!/bin/bash
 set -euo pipefail
@@ -29,6 +34,11 @@ rm -rf "${HAPROXY_BUILD_DIR}"
 EOF
 
 FROM $DOCKER_IMAGE_BASE_BUILD
+
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
 
 ARG ENABLE_TRACING
 ARG PYDANTIC_VERSION

--- a/ci/docker/serve.build.wanda.yaml
+++ b/ci/docker/serve.build.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/serve.build.Dockerfile
 srcs:
   - python/deplocks/ci/serve_base_depset_py$PYTHON.lock
 build_args:
+  - APT_PROXY
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON
   - PYTHON=$PYTHON
   - IMAGE_TYPE=base

--- a/ci/docker/servetracing.build.wanda.yaml
+++ b/ci/docker/servetracing.build.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/serve.build.Dockerfile
 srcs:
   - python/deplocks/ci/serve_tracing_depset_py3.10.lock
 build_args:
+  - APT_PROXY
   - ENABLE_TRACING=1
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build-py3.10
   - PYTHON=3.10

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -8,6 +8,11 @@ ARG BASE_IMAGE="ubuntu:22.04"
 # --- HAProxy Build Stage ---
 FROM ${BASE_IMAGE} AS haproxy-builder
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 RUN <<EOF
 #!/bin/bash
 set -euo pipefail
@@ -36,6 +41,12 @@ EOF
 
 # --- Main image ---
 FROM ${BASE_IMAGE}
+
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 # If this arg is not "autoscaler" then no autoscaler requirements will be included
 ENV TZ=America/Los_Angeles
 ENV LC_ALL=C.UTF-8

--- a/docker/base-deps/cpu.wanda.yaml
+++ b/docker/base-deps/cpu.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - python/requirements_compiled_py$PYTHON_VERSION.txt
   - python/deplocks/base_deps/ray_base_deps_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - PYTHON_VERSION
   - BASE_IMAGE=ubuntu:22.04
 tags:

--- a/docker/base-deps/cuda.wanda.yaml
+++ b/docker/base-deps/cuda.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - python/requirements_compiled_py$PYTHON_VERSION.txt
   - python/deplocks/base_deps/ray_base_deps_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - PYTHON_VERSION
   - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-devel-ubuntu22.04
 tags:

--- a/docker/base-extra-testdeps/cpu.wanda.yaml
+++ b/docker/base-extra-testdeps/cpu.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: release/ray_release/byod/byod.Dockerfile
 srcs:
   - python/deplocks/base_extra_testdeps/$IMAGE_TYPE-base_extra_testdeps_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cpu-base-extra
   - PYTHON_VERSION
   - IMAGE_TYPE

--- a/docker/base-extra-testdeps/cuda.wanda.yaml
+++ b/docker/base-extra-testdeps/cuda.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: release/ray_release/byod/byod.Dockerfile
 srcs:
   - python/deplocks/base_extra_testdeps/$IMAGE_TYPE-base_extra_testdeps_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra
   - PYTHON_VERSION
   - IMAGE_TYPE

--- a/docker/base-extra/Dockerfile
+++ b/docker/base-extra/Dockerfile
@@ -4,6 +4,11 @@ ARG BASE_IMAGE="rayproject/ray:latest"
 
 FROM "$BASE_IMAGE"
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ENV TERM=xterm
 
 ARG SSH_PORT=5020

--- a/docker/base-extra/cpu.wanda.yaml
+++ b/docker/base-extra/cpu.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: docker/base-extra/Dockerfile
 srcs:
   - python/deplocks/base_extra/ray_base_extra_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cpu-base$ARCH_SUFFIX
   - PYTHON_VERSION
 tags:

--- a/docker/base-extra/cuda.wanda.yaml
+++ b/docker/base-extra/cuda.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: docker/base-extra/Dockerfile
 srcs:
   - python/deplocks/base_extra/ray_base_extra_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cu$CUDA_VERSION-base$ARCH_SUFFIX
   - PYTHON_VERSION
 tags:

--- a/docker/base-slim/Dockerfile
+++ b/docker/base-slim/Dockerfile
@@ -5,6 +5,12 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS main-build
+
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG PYTHON_VERSION="3.10"
 ARG PYTHON_DEPSET="python/deplocks/base_slim/ray_base_slim_py${PYTHON_VERSION}.lock"
 ARG CONSTRAINTS_FILE="python/requirements_compiled_py${PYTHON_VERSION}.txt"
@@ -139,6 +145,11 @@ ENV PATH="/home/ray/.local/bin:/home/ray/anaconda3/bin:$PATH"
 
 # --- HAProxy Build Stage ---
 FROM $BASE_IMAGE AS haproxy-builder
+
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
 
 RUN <<EOF
 #!/bin/bash

--- a/docker/base-slim/cpu.wanda.yaml
+++ b/docker/base-slim/cpu.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - python/requirements_compiled_py$PYTHON_VERSION.txt
   - python/deplocks/base_slim/ray_base_slim_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - PYTHON_VERSION
   - BASE_IMAGE=ubuntu:22.04
 tags:

--- a/docker/base-slim/cuda.wanda.yaml
+++ b/docker/base-slim/cuda.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - python/requirements_compiled_py$PYTHON_VERSION.txt
   - python/deplocks/base_slim/ray_base_slim_py$PYTHON_VERSION.lock
 build_args:
+  - APT_PROXY
   - PYTHON_VERSION
   - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-runtime-ubuntu22.04
 tags:

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -3,6 +3,11 @@
 ARG BASE_IMAGE
 FROM "$BASE_IMAGE"
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 COPY python/deplocks/llm/rayllm_*.lock ./
 
 # vLLM version tag to use for EP kernel and DeepGEMM install scripts

--- a/docker/ray-llm/cuda.wanda.yaml
+++ b/docker/ray-llm/cuda.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - python/deplocks/llm/rayllm_py311_cu128.lock
   - python/deplocks/llm/rayllm_py312_cu129.lock
 build_args:
+  - APT_PROXY
   - BASE_IMAGE=cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base
 tags:
   - cr.ray.io/rayproject/ray-llm-py$PYTHON_VERSION-cu$CUDA_VERSION-base

--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -4,6 +4,11 @@
 ARG BASE_IMAGE
 FROM "$BASE_IMAGE"
 
+ARG APT_PROXY=""
+RUN if [ -n "$APT_PROXY" ]; then \
+      echo "Acquire::http::Proxy \"$APT_PROXY\";" > /etc/apt/apt.conf.d/01proxy; \
+    fi
+
 ARG PYTHON_VERSION=3.10
 ARG IMAGE_TYPE="ray"
 ARG PIP_REQUIREMENTS="python/deplocks/base_extra_testdeps/${IMAGE_TYPE}-base_extra_testdeps_py${PYTHON_VERSION}.lock"


### PR DESCRIPTION
## Summary

- Add `ARG APT_PROXY=""` + conditional apt proxy config to all Dockerfiles that run `apt-get install`
- Add `APT_PROXY` to `build_args` in all corresponding Wanda yaml specs
- When `APT_PROXY` is set (via Buildkite environment hook), Docker builds route apt downloads through the local apt-cacher-ng proxy
- When unset (local builds, other environments), builds work unchanged

### Dockerfiles modified (14 files)
**CI:** `forge.Dockerfile`, `base.test.Dockerfile`, `base.gpu.Dockerfile`, `base.build.Dockerfile`, `serve.build.Dockerfile`, `data.build.Dockerfile`, `runtime_env_container/Dockerfile`
**Release:** `base-deps/Dockerfile`, `base-extra/Dockerfile`, `base-slim/Dockerfile`, `ray-llm/Dockerfile`, `byod.Dockerfile`
**Release automation:** `forge_arm64.Dockerfile`, `forge_x86_64.Dockerfile`

Multi-stage Dockerfiles (`base-deps`, `base-slim`, `serve.build`) have the proxy configured in each stage that runs `apt-get`.

`manylinux.Dockerfile` was intentionally skipped as it uses `yum`, not `apt-get`.

### Wanda yamls updated (24 files)
All specs that build the above Dockerfiles now include `APT_PROXY` in their `build_args` list.

### Not changed
- Dockerfiles without `apt-get install` (they inherit packages from base images)
- `manylinux.Dockerfile` (CentOS/yum-based)
- Documentation example Dockerfiles (not part of CI)

Closes #249