### PR TITLE
Add thirdparty_files paths to post-command hook rm-rf cleanup

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -36,7 +36,7 @@ rm -rf /tmp/artifacts/test-summaries
 # These block the agent's git checkout on subsequent builds (see builds 75-80, 178).
 if [[ "${OSTYPE}" == linux* ]] && [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]]; then
   docker run --rm -v "${BUILDKITE_BUILD_CHECKOUT_PATH}:/work" alpine:latest \
-    sh -c "rm -rf /work/python/ray.egg-info /work/python/build" 2>/dev/null || true
+    sh -c "rm -rf /work/python/ray.egg-info /work/python/build /work/python/ray/thirdparty_files /work/python/ray/_private/runtime_env/agent/thirdparty_files" 2>/dev/null || true
 fi
 
 # Fix file ownership after Docker-plugin steps.


### PR DESCRIPTION
## Summary

- Adds `python/ray/thirdparty_files` and `python/ray/_private/runtime_env/agent/thirdparty_files` to the root-owned artifact cleanup in `.buildkite/hooks/post-command`
- Fixes permission denied errors on agent checkout caused by Docker-created root-owned files in these directories (build 206, slot 4)

Closes #264