### PR TITLE
Fix test_in_docker infrastructure: bazel log permissions, repo cache, and export options

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -26,6 +26,13 @@ if [[ "${OSTYPE}" == linux* ]]; then
   fi
 
   docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c "chown $(id -u) /artifact-mount/ && chmod 1777 /artifact-mount/" || true
+
+  # Ensure Bazel repository cache directory structure exists on the host.
+  # Containers mount /scratch/bazel-repo-cache:/bazel-repo-cache and Bazel's
+  # --repository_cache=/bazel-repo-cache (from .bazelrc build:ci) expects the
+  # content_addressable/sha256 subtree to be present.  Without this, Bazel
+  # throws FileNotFoundException inside both build and test containers.
+  mkdir -p /scratch/bazel-repo-cache/content_addressable/sha256 2>/dev/null || true
 elif [[ "${OSTYPE}" == msys ]]; then
   if [[ -d "/c/tmp/artifacts" ]]; then
     rm -rf /c/tmp/artifacts/*

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -266,6 +266,11 @@ def test_create_bazel_log_mount() -> None:
             "/tmp/artifacts/w00t",
             os.path.join(tmpdir, "w00t"),
         )
+        # Verify the directory is world-writable so test containers can write to it
+        import stat
+
+        mode = os.stat(os.path.join(tmpdir, "w00t")).st_mode
+        assert mode & stat.S_IWOTH, "bazel log dir should be world-writable"
 
 
 def test_get_test_results() -> None:

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -66,6 +66,9 @@ class TesterContainer(Container):
         bazel_log_dir_host = os.path.join(artifact_host, tmp_dir)
         bazel_log_dir_container = os.path.join(artifact_container, tmp_dir)
         os.mkdir(bazel_log_dir_container)
+        # Ensure the directory is world-writable so that test containers
+        # (which may run as a different UID) can create bazel event logs.
+        os.chmod(bazel_log_dir_container, 0o1777)
         return (bazel_log_dir_host, bazel_log_dir_container)
 
     def run_tests(

--- a/ci/run/bazel_export_options
+++ b/ci/run/bazel_export_options
@@ -6,10 +6,18 @@ if [[ "${OSTYPE}" == "msys" ]]; then
 else
   artifact_mount_path="/artifact-mount"
 fi
-event_json_flag=--build_event_json_file=$(mktemp /tmp/bazel_event_logs/bazel_log.XXXXX)
+# mktemp may fail if /tmp/bazel_event_logs is not writable (e.g. Docker
+# volume mount with restrictive permissions).  Omit the flag rather than
+# passing an empty path to Bazel which produces confusing errors.
+bazel_log_file=$(mktemp /tmp/bazel_event_logs/bazel_log.XXXXX 2>/dev/null) || true
+if [[ -n "${bazel_log_file}" ]]; then
+  event_json_flag="--build_event_json_file=${bazel_log_file}"
+else
+  event_json_flag=""
+fi
 logs_archive_flag=--test_env=RAY_TEST_FAILURE_LOGS_ARCHIVE_DIR="${artifact_mount_path}"/failed_test_logs
 summary_directory_flag=--test_env=RAY_TEST_SUMMARY_DIR="${artifact_mount_path}"/test-summaries
 summary_directory_host_flag=--test_env=RAY_TEST_SUMMARY_DIR_HOST=/tmp/artifacts/test-summaries
 mujoco_env_var="--test_env=LD_LIBRARY_PATH=/root/.mujoco/mujoco210/bin"
 
-echo "${event_json_flag} ${logs_archive_flag} ${summary_directory_flag} ${summary_directory_host_flag} ${mujoco_env_var}"
+echo "${event_json_flag:+${event_json_flag} }${logs_archive_flag} ${summary_directory_flag} ${summary_directory_host_flag} ${mujoco_env_var}"


### PR DESCRIPTION
## Summary

- Makes bazel event log mount directory world-writable (1777) so test containers can write regardless of UID mismatch
- Handles `mktemp` failure in `bazel_export_options` gracefully — omits `--build_event_json_file` instead of passing an empty path that causes confusing Bazel errors
- Creates `/scratch/bazel-repo-cache/content_addressable/sha256` on host in pre-command hook so Bazel's `--repository_cache` works inside all containers (same root cause as #273)

## Root Cause Analysis

Build 240's `core: minimal tests 3.12` step fails with exit 42 inside `test_in_docker`. The logs show all Bazel shards reporting `ERROR: Unable to write to '/tmp/bazel_event_logs/bazel_log.*'`. Two infrastructure issues contribute:

1. **Bazel event log directory permissions**: `_create_bazel_log_mount` creates a subdirectory under `/artifact-mount` with default permissions (755). When the test container runs as a different UID than the step container, it can't write to this directory. `mktemp` fails silently, producing `--build_event_json_file=` (empty path) which Bazel reports as an error.

2. **Repository cache missing**: The host's `/scratch/bazel-repo-cache` is mounted into test containers but may be empty/missing the `content_addressable/sha256` subtree. Bazel inside the test container then fails to fetch external dependencies.

## Changes

| File | Change |
|------|--------|
| `ci/ray_ci/tester_container.py` | `os.chmod(dir, 0o1777)` after `os.mkdir` in `_create_bazel_log_mount` |
| `ci/run/bazel_export_options` | Graceful mktemp failure handling; omit flag when dir not writable |
| `.buildkite/hooks/pre-command` | `mkdir -p /scratch/bazel-repo-cache/content_addressable/sha256` |
| `ci/ray_ci/test_linux_tester_container.py` | Added permission assertion to `test_create_bazel_log_mount` |

Closes #275