### PR TITLE
Split CI pipeline: lightweight PR builds, full suite in merge queue only

### DIFF
--- a/.buildkite/bootstrap.sh
+++ b/.buildkite/bootstrap.sh
@@ -15,16 +15,19 @@ mkdir -p /tmp/artifacts
 
 echo "--- :gear: Generating pipeline"
 
-# Select pipeline directory based on branch type:
-# - Merge queue branches (gh-readonly-queue/*) and main get the full test suite
-# - All other branches (PRs, feature branches) get only forge + lint
-if [[ "${BUILDKITE_BRANCH:-}" == gh-readonly-queue/* ]] || [[ "${BUILDKITE_BRANCH:-}" == "main" ]]; then
-  PIPELINE_DIR=".buildkite/fork-pipeline/"
-else
-  PIPELINE_DIR=".buildkite/fork-pipeline-pr/"
-fi
-echo "Branch: ${BUILDKITE_BRANCH:-unknown} -> Pipeline dir: $PIPELINE_DIR"
-echo "Pipeline mode: $(if [[ \"$PIPELINE_DIR\" == *fork-pipeline-pr* ]]; then echo 'PR (forge+lint only)'; else echo 'Full suite'; fi)"
+# Select pipeline directory based on branch type.
+# PRs get lightweight forge + lint only.
+# Merge queue and main get the full test suite.
+case "${BUILDKITE_BRANCH:-}" in
+  main|gh-readonly-queue/*)
+    PIPELINE_DIR=".buildkite/fork-pipeline/"
+    echo "Branch '${BUILDKITE_BRANCH}': using FULL pipeline"
+    ;;
+  *)
+    PIPELINE_DIR=".buildkite/fork-pipeline-pr/"
+    echo "Branch '${BUILDKITE_BRANCH:-unknown}': using PR pipeline (forge + lint only)"
+    ;;
+esac
 
 rayci -output /tmp/artifacts/pipeline.yaml \
   -config .buildkite/fork-config.yaml \

--- a/.buildkite/fork-pipeline-pr/_forge.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/_forge.rayci.yml
@@ -3,9 +3,3 @@ sort_key: "_forge"
 steps:
   - name: forge
     wanda: ci/docker/forge.wanda.yaml
-
-  - name: manylinux-x86_64
-    wanda: ci/docker/manylinux.wanda.yaml
-    env_file: rayci.env
-    env:
-      HOSTTYPE: "x86_64"

--- a/.buildkite/fork-pipeline-pr/lint.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/lint.rayci.yml
@@ -10,26 +10,5 @@ steps:
     commands:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
-      - clang_format
       - pre_commit
-      - semgrep_lint
-      - banned_words
-      - doc_readme
-      - dashboard_format
-      - copyright_format
-      - bazel_team
-      - bazel_buildifier
       - pytest_format
-      - test_coverage
-      - documentation_style
-
-  - label: ":lint-roller: pre-commit pydoclint"
-    key: pydoclint-small
-    tags:
-      - oss
-      - lint
-      - always
-    depends_on:
-      - forge
-    commands:
-      - ./ci/lint/lint.sh pre_commit_pydoclint


### PR DESCRIPTION
## Summary

- Trims `.buildkite/fork-pipeline-pr/` to only forge (no manylinux) and 2 lint checks (`pre_commit` + `pytest_format`), down from the full 13 lint checks + manylinux
- Refactors `bootstrap.sh` branch detection to use a `case` statement for clarity

## What runs where

| Stage | Steps | Expected Time |
|-------|-------|---------------|
| **PR** | forge + pre_commit + pytest_format | ~3-5 min |
| **Merge queue** | Everything (forge, lint, base, wheels, C++ builds, core tests, cicd, deps) | ~1-2 hours |

## What changed

- `.buildkite/fork-pipeline-pr/_forge.rayci.yml` — removed manylinux step (lint doesn't need it)
- `.buildkite/fork-pipeline-pr/lint.rayci.yml` — reduced from 13 lint checks + pydoclint to just `pre_commit` and `pytest_format`
- `.buildkite/bootstrap.sh` — replaced if/else with case statement (functionally equivalent, cleaner)

The full pipeline in `.buildkite/fork-pipeline/` is **unchanged**.

Closes #281