### PR TITLE
Fix /tmp/artifacts cross-slot permission failures on multi-slot agent

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -27,6 +27,12 @@ if [[ "${OSTYPE}" == linux* ]]; then
 
   docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c "chown $(id -u) /artifact-mount/ && chmod 1777 /artifact-mount/" || true
 
+  # Make any leftover artifacts from concurrent slots readable to prevent
+  # "permission denied" failures during artifact upload.
+  # Docker containers create files as root; the agent (non-root) needs read access.
+  docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest \
+    /bin/sh -c 'chmod -R a+rX /artifact-mount/' 2>/dev/null || true
+
   # Ensure Bazel repository cache directory structure exists on the host.
   # Containers mount /scratch/bazel-repo-cache:/bazel-repo-cache and Bazel's
   # --repository_cache=/bazel-repo-cache (from .bazelrc build:ci) expects the


### PR DESCRIPTION
## Summary

- Adds recursive `chmod -R a+rX` on `/tmp/artifacts` in the pre-command hook to make all existing artifacts world-readable before each step
- Prevents "permission denied" artifact upload failures when concurrent Buildkite agent slots share `/tmp/artifacts` and Docker containers create files as root

Closes #283