### PR TITLE
Replace rayci.localhost with rayrust hostname in cache/container addressing

### DIFF
--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -42,7 +42,7 @@ runner_queues:
 env:
   RAYCI_CHECKOUT_DIR: "set-by-pre-command-hook"
   RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"
-  BUILDKITE_BAZEL_CACHE_URL: "http://rayci.localhost:9090"
+  BUILDKITE_BAZEL_CACHE_URL: "http://rayrust:9090"
   RAYCI_STAGE: "premerge"
   RAYCI_DISABLE_TEST_DB: "1"
   GHCR_TOKEN: ""
@@ -59,7 +59,7 @@ hook_env_keys:
 docker_plugin:
   allow_mount_buildkite_agent: true
   add-host:
-    - "rayci.localhost:host-gateway"
+    - "rayrust:host-gateway"
   volumes:
     - "/scratch/bazel-repo-cache:/bazel-repo-cache"
 

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -110,7 +110,7 @@ class LinuxContainer(Container):
     ) -> List[str]:
         extra_args = [
             "--add-host",
-            "rayci.localhost:host-gateway",
+            "rayrust:host-gateway",
         ]
         if self.tmp_filesystem:
             extra_args += [


### PR DESCRIPTION
## Summary

- Replace all `rayci.localhost` references with `rayrust` (Tailscale-resolvable hostname) to align repo config with the NixOS host `cacheHost` variable
- Update `BUILDKITE_BAZEL_CACHE_URL` in `fork-config.yaml` to `http://rayrust:9090`
- Update `--add-host` entries in both `fork-config.yaml` and `ci/ray_ci/linux_container.py` to `rayrust:host-gateway`

`host-gateway` is preserved since caches still run on the same host. When caches move to a separate VM, only the NixOS `cacheHost` variable needs updating — no further repo changes.

Closes #288