### PR TITLE
Replace hardcoded infrastructure paths with env vars for multi-host scalability

### DIFF
--- a/.buildkite/bootstrap.sh
+++ b/.buildkite/bootstrap.sh
@@ -15,7 +15,6 @@ buildkite-agent --version
 # collisions when multiple agent slots share a host).
 ARTIFACT_DIR="${RAYCI_ARTIFACT_DIR:-/tmp/artifacts}"
 mkdir -p "$ARTIFACT_DIR"
-mkdir -p /tmp/artifacts
 
 echo "--- :gear: Generating pipeline"
 
@@ -144,6 +143,12 @@ fi
 if [[ "$ARTIFACT_DIR" != "/tmp/artifacts" ]]; then
   echo "--- :pencil2: Rewriting artifact paths to $ARTIFACT_DIR"
   sed -i "s|/tmp/artifacts|${ARTIFACT_DIR}|g" /tmp/artifacts/pipeline_flat.yaml
+fi
+
+# Rewrite bazel-repo-cache host paths if using a custom location.
+if [[ "${RAYCI_BAZEL_REPO_CACHE:-}" != "" && "$RAYCI_BAZEL_REPO_CACHE" != "/scratch/bazel-repo-cache" ]]; then
+  echo "--- :pencil2: Rewriting bazel-repo-cache paths to $RAYCI_BAZEL_REPO_CACHE"
+  sed -i "s|/scratch/bazel-repo-cache|${RAYCI_BAZEL_REPO_CACHE}|g" /tmp/artifacts/pipeline_flat.yaml
 fi
 
 echo "--- :buildkite: Uploading pipeline"

--- a/.buildkite/fork-config.yaml
+++ b/.buildkite/fork-config.yaml
@@ -42,7 +42,7 @@ runner_queues:
 env:
   RAYCI_CHECKOUT_DIR: "set-by-pre-command-hook"
   RAYCI_GLOBAL_CONFIG: "ci/ray_ci/fork_config.yaml"
-  BUILDKITE_BAZEL_CACHE_URL: "http://rayci.localhost:9090"
+  BUILDKITE_BAZEL_CACHE_URL: "http://rayrust:9090"
   RAYCI_STAGE: "premerge"
   RAYCI_DISABLE_TEST_DB: "1"
   GHCR_TOKEN: ""
@@ -59,9 +59,9 @@ hook_env_keys:
 docker_plugin:
   allow_mount_buildkite_agent: true
   add-host:
-    - "rayci.localhost:host-gateway"
+    - "rayrust:host-gateway"
   volumes:
-    - "/scratch/bazel-repo-cache:/bazel-repo-cache"
+    - "${RAYCI_BAZEL_REPO_CACHE:-/scratch/bazel-repo-cache}:/bazel-repo-cache"
 
 # Tags that cause steps to be unconditionally skipped.
 skip_tags:

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -34,7 +34,8 @@ if [[ "${OSTYPE}" == linux* ]]; then
   # --repository_cache=/bazel-repo-cache (from .bazelrc build:ci) expects the
   # content_addressable/sha256 subtree to be present.  Without this, Bazel
   # throws FileNotFoundException inside both build and test containers.
-  mkdir -p /scratch/bazel-repo-cache/content_addressable/sha256 2>/dev/null || true
+  BAZEL_REPO_CACHE="${RAYCI_BAZEL_REPO_CACHE:-/scratch/bazel-repo-cache}"
+  mkdir -p "$BAZEL_REPO_CACHE/content_addressable/sha256" 2>/dev/null || true
 elif [[ "${OSTYPE}" == msys ]]; then
   if [[ -d "/c/tmp/artifacts" ]]; then
     rm -rf /c/tmp/artifacts/*

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -16,7 +16,7 @@ class BuilderContainer(LinuxContainer):
             f"manylinux-{architecture}",
             volumes=[
                 f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci",
-                "/scratch/bazel-repo-cache:/bazel-repo-cache",
+                f"{os.environ.get('RAYCI_BAZEL_REPO_CACHE', '/scratch/bazel-repo-cache')}:/bazel-repo-cache",
             ],
         )
         python_version_info = PYTHON_VERSIONS.get(python_version)

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -108,9 +108,10 @@ class LinuxContainer(Container):
         self,
         gpu_ids: Optional[List[int]] = None,
     ) -> List[str]:
+        cache_host = os.environ.get("RAYCI_CACHE_HOST", "rayrust")
         extra_args = [
             "--add-host",
-            "rayci.localhost:host-gateway",
+            f"{cache_host}:host-gateway",
         ]
         if self.tmp_filesystem:
             extra_args += [

--- a/ci/ray_ci/linux_tester_container.py
+++ b/ci/ray_ci/linux_tester_container.py
@@ -28,7 +28,7 @@ class LinuxTesterContainer(TesterContainer, LinuxContainer):
             volumes=[
                 f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/ray-mount",
                 "/var/run/docker.sock:/var/run/docker.sock",
-                "/scratch/bazel-repo-cache:/bazel-repo-cache",
+                f"{os.environ.get('RAYCI_BAZEL_REPO_CACHE', '/scratch/bazel-repo-cache')}:/bazel-repo-cache",
             ],
             python_version=python_version,
             tmp_filesystem=tmp_filesystem,


### PR DESCRIPTION
## Summary

- Introduce `RAYCI_CACHE_HOST` (default: `rayrust`) and `RAYCI_BAZEL_REPO_CACHE` (default: `/scratch/bazel-repo-cache`) env vars across all CI infrastructure paths
- When unset, behavior is identical to current defaults — no breaking change
- Enables multi-host agent deployments where each VM can point at a different cache host

## Changes

| File | Change |
|------|--------|
| `fork-config.yaml` | `rayci.localhost` → `rayrust`; volume mount uses `${RAYCI_BAZEL_REPO_CACHE:-...}` |
| `linux_container.py` | `--add-host` uses `RAYCI_CACHE_HOST` env var |
| `linux_tester_container.py` | Volume mount uses `RAYCI_BAZEL_REPO_CACHE` env var |
| `builder_container.py` | Volume mount uses `RAYCI_BAZEL_REPO_CACHE` env var |
| `hooks/pre-command` | `mkdir` uses `RAYCI_BAZEL_REPO_CACHE` env var |
| `bootstrap.sh` | Adds sed rewrite for custom bazel-repo-cache paths; uses `$ARTIFACT_DIR` consistently |

Closes #290
Closes #288