### PR TITLE
Fix artifact_paths mismatch: bootstrap sed rewrites upload paths to wrong slot

### DIFF
--- a/.buildkite/bootstrap.sh
+++ b/.buildkite/bootstrap.sh
@@ -140,10 +140,16 @@ else
 fi
 
 # Rewrite artifact paths in the generated pipeline if using a custom directory.
-# This updates Docker volume mounts and artifact_paths inside the YAML.
+# Docker volume mounts use the per-slot ARTIFACT_DIR so each slot writes to its
+# own directory.  artifact_paths globs must use a wildcard so Buildkite uploads
+# artifacts regardless of which slot runs the job (the bootstrap slot that ran
+# the sed is not necessarily the slot that runs the downstream job).
 if [[ "$ARTIFACT_DIR" != "/tmp/artifacts" ]]; then
   echo "--- :pencil2: Rewriting artifact paths to $ARTIFACT_DIR"
-  sed -i "s|/tmp/artifacts|${ARTIFACT_DIR}|g" /tmp/artifacts/pipeline_flat.yaml
+  # 1. Rewrite Docker volume mounts (lines containing -v or --volume)
+  sed -i "/-v \|--volume/s|/tmp/artifacts|${ARTIFACT_DIR}|g" /tmp/artifacts/pipeline_flat.yaml
+  # 2. Rewrite artifact_paths to glob across all slots
+  sed -i "s|artifact_paths:\(.*\)/tmp/artifacts|artifact_paths:\1/scratch/artifacts/*|g" /tmp/artifacts/pipeline_flat.yaml
 fi
 
 echo "--- :buildkite: Uploading pipeline"


### PR DESCRIPTION
## Summary

- Splits the bootstrap `sed` rewrite into two targeted passes: one for Docker volume mounts (per-slot), one for `artifact_paths` globs (wildcard across all slots)
- Fixes artifact upload failures when downstream jobs run on a different agent slot than the bootstrap step

## Problem

Build 272 showed that the blanket `sed` replacing `/tmp/artifacts` with the slot-specific `$ARTIFACT_DIR` also rewrote `artifact_paths` globs. When a downstream job ran on slot 4, artifacts were written to `/scratch/artifacts/rayrust-default-4/`, but Buildkite tried to upload from `/scratch/artifacts/rayrust-default-1/` (baked in at bootstrap time on slot 1).

## Fix

1. Docker volume mount lines (`-v`/`--volume`) → rewritten to per-slot `$ARTIFACT_DIR`
2. `artifact_paths` globs → rewritten to `/scratch/artifacts/*` so any slot's artifacts are uploaded

Closes #292