### PR TITLE
Clean up dead code: duplicate --python-version flag and unused --workers in core.rayci.yml

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -52,14 +52,14 @@ steps:
   - label: ":ray: core: ray client tests"
     tags:
       - ray_client
-    instance_type: large
+    instance_type: medium
     # concurrency group removed — agent spawn count is the only
     # throughput lever.  Upstream Ray used concurrency: 4 for their
     # cloud CI; we don't need it on dedicated hardware.
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/...   core
         --install-mask all-ray-libraries
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
+        --parallelism-per-worker 2
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags ray_client
     depends_on:
@@ -270,7 +270,6 @@ steps:
         --test-env=RAY_MINIMAL=1
         --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
         --only-tags minimal
-        --python-version {{matrix}}
         --except-tags basic_test,manual,cgroup
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 2


### PR DESCRIPTION
## Summary

- Remove duplicate `--python-version {{matrix}}` flag in minimal tests command block (line 273) — second occurrence silently overrides the first
- Remove dead `--workers`/`--worker-id` flags from `ray_client` step — no `parallelism:` key means these resolve to `--workers 1 --worker-id 0` (no-op)
- Downsize `ray_client` from `instance_type: large` to `medium` — only 6 test files with no sharding

No behavioral change to test execution.

Closes #303