### PR TITLE
Remove unused corebuild-py3.12 from CI build matrix

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -5,15 +5,12 @@ depends_on:
   - ray-dashboard-build
 steps:
   # builds
-  - name: corebuild-multipy
-    label: "wanda: corebuild-py{{matrix}}"
+  - name: corebuild
+    label: "wanda: corebuild-py3.10"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    matrix:
-      - "3.10"
-      - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "3.10"
       BASE_TYPE: "build"
       BUILD_VARIANT: "build"
     depends_on: oss-ci-base_build-multipy
@@ -46,7 +43,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --except-tags custom_setup,gpu_objects
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: ray client tests"
@@ -63,7 +60,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags ray_client
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: redis tests"
@@ -84,7 +81,7 @@ steps:
         --except-tags custom_setup
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: memory pressure tests"
@@ -103,7 +100,7 @@ steps:
       - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)
         --test_tag_filters=mem_pressure -- //python/ray/tests/...
     job_env: corebuild-py3.10
-    depends_on: corebuild-multipy
+    depends_on: corebuild
 
   - label: ":ray: core: out of disk tests"
     tags:
@@ -118,7 +115,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --only-tags=tmpfs --tmp-filesystem=tmpfs
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: out of disk redis tests"
@@ -136,7 +133,7 @@ steps:
         --only-tags=tmpfs --tmp-filesystem=tmpfs
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   # Doc tests disabled — low priority for a Rust port, ~28min each.
@@ -158,7 +155,7 @@ steps:
   #       --python-version 3.10 --build-name corebuild-py3.10
   #       --skip-ray-installation
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   # ---------------------------------------------------------------
@@ -185,7 +182,7 @@ steps:
   #       "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
   #       "./python/ray/dashboard/tests/run_ui_tests.sh"
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   - label: ":ray: core: debug tests"
@@ -205,7 +202,7 @@ steps:
         --only-tags debug_tests
         --except-tags kubernetes,manual
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: asan tests"
@@ -225,7 +222,7 @@ steps:
         --only-tags asan_tests
         --except-tags kubernetes,manual
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: wheel tests"
@@ -245,7 +242,7 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
     depends_on:
       - manylinux-x86_64
-      - corebuild-multipy
+      - corebuild
       - forge
       - ray-wheel-build
 
@@ -329,7 +326,7 @@ steps:
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
         "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: cpp tests"
@@ -345,7 +342,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --cache-test-results --parallelism-per-worker 2
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   # ---------------------------------------------------------------
@@ -373,7 +370,7 @@ steps:
   #       --build-type asan-clang --cache-test-results --parallelism-per-worker 2
   #       --python-version 3.10 --build-name corebuild-py3.10
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   # - label: ":ray: core: cpp ubsan tests"
@@ -385,7 +382,7 @@ steps:
   #       --build-type ubsan --except-tags no_ubsan,cgroup
   #       --cache-test-results --parallelism-per-worker 2
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   # - label: ":ray: core: cpp tsan tests"
@@ -397,7 +394,7 @@ steps:
   #       --build-type tsan-clang --except-tags no_tsan,cgroup
   #       --cache-test-results --parallelism-per-worker 2
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   - label: ":ray: core: flaky tests"
@@ -418,7 +415,7 @@ steps:
         --run-flaky-tests
         --except-tags multi_gpu,cgroup
     depends_on:
-      - corebuild-multipy
+      - corebuild
       - forge
 
   # ---------------------------------------------------------------
@@ -451,7 +448,7 @@ steps:
   #       --python-version 3.10 --build-name corebuild-py3.10
   #       --cache-test-results --parallelism-per-worker 2
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   # ---------------------------------------------------------------
@@ -472,7 +469,7 @@ steps:
   #       --build-type java
   #       --only-tags needs_java
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge
 
   # ---------------------------------------------------------------
@@ -496,5 +493,5 @@ steps:
   #       --only-tags spark_on_ray
   #       --python-version 3.10 --build-name corebuild-py3.10
   #   depends_on:
-  #     - corebuild-multipy
+  #     - corebuild
   #     - forge


### PR DESCRIPTION
## Summary

- Remove unused `corebuild-py3.12` from the build matrix in `.buildkite/fork-pipeline/core.rayci.yml`
- Rename step from `corebuild-multipy` to `corebuild` since it now only targets py3.10
- Update all `depends_on` references in the file accordingly

No test step in the fork pipeline uses the py3.12 image, so building it wastes CI time (wanda image build + ray wheel build).

Closes #302