### PR TITLE
Fix single test failure annotations in Buildkite post-command hook

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -15,9 +15,9 @@ set -ex
 ARTIFACT_DIR="${RAYCI_ARTIFACT_DIR:-/tmp/artifacts}"
 
 if [ -d "$ARTIFACT_DIR/test-summaries" ] && [ "$(ls -A "$ARTIFACT_DIR/test-summaries")" ]; then
-    # Only upload annotations if there are at least 2 files in the directory:
-    # 1 header and 1 failed test.
-    if [ "$(find "$ARTIFACT_DIR/test-summaries" -maxdepth 1 -name '*.txt' | wc -l)" -ge 2 ]; then
+    # Upload annotations if there is at least 1 test failure summary file.
+    # Each failing pytest writes its own .txt; there is no separate header.
+    if [ "$(find "$ARTIFACT_DIR/test-summaries" -maxdepth 1 -name '*.txt' | wc -l)" -ge 1 ]; then
       echo "Test summaries for ${BUILDKITE_JOB_ID} ${BUILDKITE_LABEL}" | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --style error --context "${BUILDKITE_JOB_ID}"
       cat "$ARTIFACT_DIR/test-summaries"/*.txt | head -n 20 | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --append --style error --context "${BUILDKITE_JOB_ID}"
     fi


### PR DESCRIPTION
## Summary

- Fix the post-command hook to annotate single test failures (threshold `>= 1` instead of `>= 2`)
- The old `>= 2` threshold was based on the incorrect assumption that a separate header file existed alongside per-test summary files
- In reality, `conftest.py::append_short_test_summary` writes exactly one `.txt` per failing test with no header, so single test failures were silently unreported

## Context

Build 335 on main had `ray-core-python-tests-g4-s2` fail with exit status 42, but no Buildkite annotation was created. Without Buildkite API access (see #298), the specific failing test could not be identified. This fix ensures future single-test failures are always annotated in Buildkite.

The g4-s2 failure is likely transient — build 334 (identical test set minus `test_multi_node.py`) passed all individual tests. When this PR merges and triggers a new build on main, the next build will either:
1. Pass g4-s2, confirming the failure was transient
2. Fail g4-s2 again, but now with an annotation identifying the specific test

Closes #300