### PR TITLE
fix: annotate single test failures in Buildkite post-command hook

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -13,9 +13,9 @@
 set -ex
 
 if [ -d "/tmp/artifacts/test-summaries" ] && [ "$(ls -A /tmp/artifacts/test-summaries)" ]; then
-    # Only upload annotations if there are at least 2 files in the directory:
-    # 1 header and 1 failed test.
-    if [ "$(find /tmp/artifacts/test-summaries -maxdepth 1 -name '*.txt' | wc -l)" -ge 2 ]; then
+    # Upload annotations if there is at least 1 test failure summary file.
+    # Each failing pytest writes its own .txt; there is no separate header.
+    if [ "$(find /tmp/artifacts/test-summaries -maxdepth 1 -name '*.txt' | wc -l)" -ge 1 ]; then
       echo "Test summaries for ${BUILDKITE_JOB_ID} ${BUILDKITE_LABEL}" | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --style error --context "${BUILDKITE_JOB_ID}"
       cat /tmp/artifacts/test-summaries/*.txt | head -n 20 | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --append --style error --context "${BUILDKITE_JOB_ID}"
     fi


### PR DESCRIPTION
## Summary

- Fix the post-command hook annotation threshold from `>= 2` to `>= 1` so single test failures are reported in Buildkite
- Documents investigation of build 335 g4-s2 failure

## Investigation of build 335

Downloaded the job log for `ray-core-python-tests-g4-s2` (job ID `019d2302-f964-46b6-a458-9b9590be937b`). The sole failing test was:

```
FAILED python/ray/tests/test_ray_init.py::test_ray_init_with_runtime_env_as_dict
```

**Root cause:** The test timed out waiting for GCS server to start (`wait_for_persisted_port`). Bazel sent SIGTERM after the test timeout expired, causing `SystemExit: 15`.

**Assessment:** This is a transient flake — build 334 passed the same test, and the very next test in the same file (`test_ray_init_with_runtime_env_as_object`) passed in the same run. The test exercises GCS server startup, which is Rust-port-relevant. Per project rules, it must **not** be disabled.

## Why the annotation fix matters

The g4-s2 failure had no Buildkite annotation because the post-command hook required `>= 2` `.txt` files in `test-summaries/`. Each failing pytest writes exactly one `.txt` with no separate header, so a single test failure produced 1 file and was silently skipped. This made it impossible to identify the failing test without downloading the full job log via the API.

## Change

One line: `>= 2` → `>= 1` in `.buildkite/hooks/post-command`

This is a zero-risk observability improvement — it only affects annotation visibility, not test execution.

Closes #300