### PR TITLE
fix: ruff import lint + wheel test symlink loop

### DIFF
--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -126,7 +126,7 @@ case "$BUILD_TYPE" in
     # The wheel doesn't ship test files, but some test conftest.py files
     # import from ray.tests.conftest. Symlink the source tree's tests dir
     # into site-packages so these imports resolve.
-    ln -sf /rayci/python/ray/tests "${RAY_SITE_DIR}/tests"
+    ln -sfn /rayci/python/ray/tests "${RAY_SITE_DIR}/tests"
 
     apply_install_mask "${RAY_SITE_DIR}"
 

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -9,8 +9,7 @@ import yaml
 
 import ray
 from ray._common.test_utils import wait_for_condition
-from ray._private.runtime_env import conda as runtime_env_conda
-from ray._private.runtime_env import dependency_utils
+from ray._private.runtime_env import conda as runtime_env_conda, dependency_utils
 from ray._private.runtime_env.dependency_utils import (
     INTERNAL_PIP_FILENAME,
     MAX_INTERNAL_PIP_FILENAME_TRIES,


### PR DESCRIPTION
## Summary
- Combine two duplicate `from ray._private.runtime_env import ...` lines into one (ruff lint fix)
- Fix infinite symlink loop in `tests.env.Dockerfile` that was breaking all wheel-based test steps (wheel tests, conda test) across builds 547-551

## Symlink bug details
`ln -sf` without `-n` creates a symlink *inside* an existing directory target instead of replacing it. When `RAY_SITE_DIR` resolves to the source tree (`/rayci/python/ray`), this produces `/rayci/python/ray/tests/tests -> /rayci/python/ray/tests` — an infinite loop that crashes bazel glob evaluation.

Fix: `ln -sf` → `ln -sfn`

## Test plan
- [x] ruff lint passes (build 550)
- [ ] wheel tests pass with the symlink fix (merge queue build)
