### PR TITLE
tests: use random dashboard port to avoid flaky port conflicts

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -784,7 +784,7 @@ def call_ray_start(request):
 def call_ray_start_context(request):
     default_cmd = (
         "ray start --head --num-cpus=1 --min-worker-port=0 "
-        "--max-worker-port=0 --port 0"
+        "--max-worker-port=0 --port 0 --dashboard-port 0"
     )
     parameter = getattr(request, "param", default_cmd)
     env = None

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -95,7 +95,10 @@ def test_ray_init_existing_instance(call_ray_start, address):
 def test_ray_init_existing_instance_via_blocked_ray_start():
     """Run a blocked ray start command and check that ray.init() connects to it."""
     blocked_start_cmd = subprocess.Popen(
-        ["ray", "start", "--head", "--block", "--num-cpus", "1999", "--dashboard-port", "0"],
+        [
+            "ray", "start", "--head", "--block",
+            "--num-cpus", "1999", "--dashboard-port", "0",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -96,8 +96,14 @@ def test_ray_init_existing_instance_via_blocked_ray_start():
     """Run a blocked ray start command and check that ray.init() connects to it."""
     blocked_start_cmd = subprocess.Popen(
         [
-            "ray", "start", "--head", "--block",
-            "--num-cpus", "1999", "--dashboard-port", "0",
+            "ray",
+            "start",
+            "--head",
+            "--block",
+            "--num-cpus",
+            "1999",
+            "--dashboard-port",
+            "0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -72,7 +72,7 @@ def test_ray_init_existing_instance(call_ray_start, address):
 
     # Start a second local Ray instance.
     try:
-        subprocess.check_output("ray start --head", shell=True)
+        subprocess.check_output("ray start --head --dashboard-port 0", shell=True)
         # If there are multiple local instances, connect to the latest.
         res = ray.init(address=address)
         assert res.address_info["gcs_address"] != ray_address
@@ -95,7 +95,7 @@ def test_ray_init_existing_instance(call_ray_start, address):
 def test_ray_init_existing_instance_via_blocked_ray_start():
     """Run a blocked ray start command and check that ray.init() connects to it."""
     blocked_start_cmd = subprocess.Popen(
-        ["ray", "start", "--head", "--block", "--num-cpus", "1999"],
+        ["ray", "start", "--head", "--block", "--num-cpus", "1999", "--dashboard-port", "0"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -202,7 +202,7 @@ def test_auto_init_non_client(call_ray_start):
 
 @pytest.mark.parametrize(
     "call_ray_start",
-    ["ray start --head --ray-client-server-port 25036 --port 0"],
+    ["ray start --head --ray-client-server-port 25036 --port 0 --dashboard-port 0"],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -9,8 +9,7 @@ import yaml
 
 import ray
 from ray._common.test_utils import wait_for_condition
-from ray._private.runtime_env import conda as runtime_env_conda
-from ray._private.runtime_env import dependency_utils
+from ray._private.runtime_env import conda as runtime_env_conda, dependency_utils
 from ray._private.runtime_env.dependency_utils import (
     INTERNAL_PIP_FILENAME,
     MAX_INTERNAL_PIP_FILENAME_TRIES,


### PR DESCRIPTION
## Summary
- Add `--dashboard-port 0` to the shared `call_ray_start` fixture default command and all inline `ray start` invocations in `test_ray_init.py`
- Prevents flaky "Failed to bind to 127.0.0.1:8265" failures when test cleanup is slow under heavy CI load
- Build 554 failed this way on pm2 while the same shard passed on pm4 in build 555

## Test plan
- [ ] Quick checks pass on the PR
- [ ] Merge queue build passes