### PR TITLE
fix: constrain pip install to prevent otel version skew

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -312,8 +312,13 @@ install_pip_packages() {
     fi
   fi
 
-  # TODO(ray-ci): pin the dependencies.
-  CC=gcc retry_pip_install pip install -Ur "${WORKSPACE_DIR}/python/requirements.txt"
+  # Use compiled constraints to prevent unconstrained dependency upgrades
+  # from breaking the environment (e.g. opentelemetry version skew).
+  _constraints_args=""
+  if [[ -f "${WORKSPACE_DIR}/python/requirements_compiled.txt" && "${OSTYPE}" != "msys" ]]; then
+    _constraints_args="-c ${WORKSPACE_DIR}/python/requirements_compiled.txt"
+  fi
+  CC=gcc retry_pip_install pip install -U ${_constraints_args} -r "${WORKSPACE_DIR}/python/requirements.txt"
 
   # Install deeplearning libraries (Torch + TensorFlow)
   if [[ -n "${TORCH_VERSION-}" || "${DL-}" == "1" || "${RLLIB_TESTING-}" == 1 || "${TRAIN_TESTING-}" == 1 || "${TUNE_TESTING-}" == 1 || "${DOC_TESTING-}" == 1 ]]; then
@@ -383,7 +388,7 @@ install_pip_packages() {
 
   # Install delayed packages
   if [[ "${#delayed_packages[@]}" -gt 0 ]]; then
-    pip install -U -c "${WORKSPACE_DIR}/python/requirements.txt" "${delayed_packages[@]}"
+    pip install -U -c "${WORKSPACE_DIR}/python/requirements.txt" ${_constraints_args} "${delayed_packages[@]}"
   fi
 
   # Additional Tune dependency for Horovod.

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -314,11 +314,11 @@ install_pip_packages() {
 
   # Use compiled constraints to prevent unconstrained dependency upgrades
   # from breaking the environment (e.g. opentelemetry version skew).
-  _constraints_args=""
+  _constraints_args=()
   if [[ -f "${WORKSPACE_DIR}/python/requirements_compiled.txt" && "${OSTYPE}" != "msys" ]]; then
-    _constraints_args="-c ${WORKSPACE_DIR}/python/requirements_compiled.txt"
+    _constraints_args=(-c "${WORKSPACE_DIR}/python/requirements_compiled.txt")
   fi
-  CC=gcc retry_pip_install pip install -U ${_constraints_args} -r "${WORKSPACE_DIR}/python/requirements.txt"
+  CC=gcc retry_pip_install pip install -U "${_constraints_args[@]}" -r "${WORKSPACE_DIR}/python/requirements.txt"
 
   # Install deeplearning libraries (Torch + TensorFlow)
   if [[ -n "${TORCH_VERSION-}" || "${DL-}" == "1" || "${RLLIB_TESTING-}" == 1 || "${TRAIN_TESTING-}" == 1 || "${TUNE_TESTING-}" == 1 || "${DOC_TESTING-}" == 1 ]]; then
@@ -388,7 +388,7 @@ install_pip_packages() {
 
   # Install delayed packages
   if [[ "${#delayed_packages[@]}" -gt 0 ]]; then
-    pip install -U -c "${WORKSPACE_DIR}/python/requirements.txt" ${_constraints_args} "${delayed_packages[@]}"
+    pip install -U -c "${WORKSPACE_DIR}/python/requirements.txt" "${_constraints_args[@]}" "${delayed_packages[@]}"
   fi
 
   # Additional Tune dependency for Horovod.


### PR DESCRIPTION
## Summary

- Add compiled constraints (`-c requirements_compiled.txt`) to the unconstrained `pip install` calls in `install-dependencies.sh`
- Fixes dashboard startup failures (`AttributeError: PROMETHEUS_HTTP_TEXT_METRIC_EXPORTER`) caused by opentelemetry version skew
- Matches the constraint pattern already used for ML/test requirements later in the same function

## Root cause

`opentelemetry-exporter-prometheus 0.62b0` (released 2026-04-09) requires a symbol from a newer `opentelemetry-semantic-conventions` than what's pinned. The image build installs pinned deps first via `requirements_compiled.txt`, then `install-dependencies.sh` line 316 does an unconstrained reinstall from `requirements.txt` that pulls the new exporter, creating a version mismatch.

## What changed

Two call sites in `install_pip_packages()`:

1. **Main requirements install** (was line 316): now uses `-c requirements_compiled.txt` (with the same platform guard used elsewhere in the function)
2. **Delayed packages install** (was line 386): same constraint added

## Test plan

- [ ] Trigger a CI build and verify the failing `core: python tests [g4_s2]` shard passes
- [ ] Verify dashboard starts successfully (no `PROMETHEUS_HTTP_TEXT_METRIC_EXPORTER` error)

See `handoffs/buildkite-otel-skew-2026-04-16.md` for full investigation.
