### PR TITLE
fix: add rust/ to ray-core Docker build context

### DIFF
--- a/ci/docker/ray-core.wanda.yaml
+++ b/ci/docker/ray-core.wanda.yaml
@@ -9,6 +9,7 @@ srcs:
   - bazel/
   - thirdparty/
   - src/
+  - rust/
   - gen_ray_pkg.py
   - python/ray/__init__.py
   - python/ray/_raylet.pxd


### PR DESCRIPTION
The wanda srcs list controls what gets copied into the Docker build.
Without rust/, Bazel cannot find the //rust:_raylet target.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>