### PR TITLE
Update stale comments in Buildkite hooks to reference RAYCI_ARTIFACT_DIR

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,12 +1,12 @@
 #!/bin/bash
-# This script is executed by Buildkite on the host machine.
-# In contrast, our build jobs are run in Docker containers.
-# This means that even though our build jobs write to
-# `/artifact-mount`, the directory on the host machine is
-# actually `/tmp/artifacts`.
-# We clean up the artifacts directory before any command and
-# after uploading artifacts to make sure no stale artifacts
-# remain on the node when a Buildkite runner is re-used.
+# This script is executed by Buildkite on the host machine after
+# artifact upload (post-artifact hook).
+# Our build jobs run in Docker containers that write to
+# `/artifact-mount`, which maps to `$RAYCI_ARTIFACT_DIR`
+# (defaulting to `/tmp/artifacts`) on the host.
+# We clean up the artifacts directory after uploading artifacts
+# to make sure no stale artifacts remain on the node when a
+# Buildkite runner is re-used.
 set -ex
 
 ARTIFACT_DIR="${RAYCI_ARTIFACT_DIR:-/tmp/artifacts}"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -3,7 +3,7 @@
 # In contrast, our build jobs are run in Docker containers.
 # This means that even though our build jobs write to
 # `/artifact-mount`, the directory on the host machine is
-# actually `/tmp/artifacts`.
+# `$RAYCI_ARTIFACT_DIR` (defaulting to `/tmp/artifacts`).
 # Here, we cat all text files in artifact-mount/test-summaries
 # and upload them as a Buildkite annotation.
 # These files contain a condensed summary of all failing pytest


### PR DESCRIPTION
## Summary

- Update header comments in `.buildkite/hooks/post-artifact` to reference `$RAYCI_ARTIFACT_DIR` instead of hardcoded `/tmp/artifacts`, and fix the timing description (this hook runs *after* upload, not "before any command")
- Update header comment in `.buildkite/hooks/post-command` to reference `$RAYCI_ARTIFACT_DIR` instead of hardcoded `/tmp/artifacts`

No functional changes — comments only.

Closes #317