### PR TITLE
ci: add Rust packaging preflight to PR pipeline

### DIFF
--- a/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
@@ -14,6 +14,7 @@ steps:
     depends_on:
       - forge
     tags:
+      - always
       - release_wheels
 
   - name: rust-ray-java
@@ -26,5 +27,6 @@ steps:
     depends_on:
       - forge
     tags:
+      - always
       - release_wheels
       - java

--- a/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
@@ -1,0 +1,30 @@
+group: rust packaging preflight
+sort_key: rust-packaging-preflight
+steps:
+  # Fast PR signal for the Rust _raylet packaging path. The full merge-queue
+  # pipeline still runs the complete Python-version matrix and wheel tests.
+  - name: rust-ray-core-py310
+    label: "wanda: rust ray-core py3.10 (x86_64)"
+    wanda: ci/docker/ray-core.wanda.yaml
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "3.10"
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+    depends_on:
+      - forge
+    tags:
+      - release_wheels
+
+  - name: rust-ray-java
+    label: "wanda: rust java build (x86_64)"
+    wanda: ci/docker/ray-java.wanda.yaml
+    env_file: rayci.env
+    env:
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+    depends_on:
+      - forge
+    tags:
+      - release_wheels
+      - java


### PR DESCRIPTION
## Summary
- add a PR-only Rust packaging preflight group
- build `ray-core.wanda.yaml` for py3.10 to catch Rust `_raylet.so` packaging failures before merge queue
- build `ray-java.wanda.yaml` to catch Java/native Bazel graph failures like missing linker-script exports

## Why
The full merge-queue pipeline currently takes too long to expose early wanda image failures. This keeps full CI intact while giving PRs a fast signal on the Rust packaging path.

## Testing
- not run locally: rayci is only available in the Buildkite environment
