### PR TITLE
fix: prebuild Rust _raylet for packaging preflight

### DIFF
--- a/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
@@ -30,3 +30,36 @@ steps:
       - always
       - release_wheels
       - java
+
+  - name: rust-corebuild-py310
+    label: "wanda: rust corebuild py3.10"
+    wanda: ci/docker/core.build.wanda.yaml
+    env:
+      PYTHON: "3.10"
+      BASE_TYPE: "build"
+      BUILD_VARIANT: "build"
+    depends_on:
+      - forge
+    tags:
+      - always
+      - cibase
+
+  - label: ":ray: rust smoke tests"
+    tags:
+      - always
+      - python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker --
+        //python/ray/dashboard:test_dashboard
+        //python/ray/tests:test_bundle_label_selector
+        //python/ray/tests:test_namespace
+        //python/ray/tests:test_nested_task
+        //python/ray/tests:test_multiprocessing_standalone
+        //python/ray/tests:test_placement_group_mini_integration
+        core
+        --install-mask all-ray-libraries
+        --python-version 3.10 --build-name corebuild-py3.10
+    depends_on:
+      - rust-corebuild-py310
+      - forge

--- a/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
@@ -31,6 +31,28 @@ steps:
       - release_wheels
       - java
 
+  - name: rust-oss-ci-base-test-py310
+    label: "wanda: rust oss-ci-base_test py3.10"
+    wanda: ci/docker/base.test.wanda.yaml
+    env:
+      PYTHON: "3.10"
+    depends_on:
+      - forge
+    tags:
+      - always
+      - cibase
+
+  - name: rust-oss-ci-base-build-py310
+    label: "wanda: rust oss-ci-base_build py3.10"
+    wanda: ci/docker/base.build.wanda.yaml
+    env:
+      PYTHON: "3.10"
+    depends_on:
+      - rust-oss-ci-base-test-py310
+    tags:
+      - always
+      - cibase
+
   - name: rust-corebuild-py310
     label: "wanda: rust corebuild py3.10"
     wanda: ci/docker/core.build.wanda.yaml
@@ -39,7 +61,7 @@ steps:
       BASE_TYPE: "build"
       BUILD_VARIANT: "build"
     depends_on:
-      - forge
+      - rust-oss-ci-base-build-py310
     tags:
       - always
       - cibase

--- a/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
+++ b/.buildkite/fork-pipeline-pr/rust-packaging.rayci.yml
@@ -31,6 +31,19 @@ steps:
       - release_wheels
       - java
 
+  - name: rust-ray-dashboard
+    label: "wanda: rust dashboard (x86_64)"
+    wanda: ci/docker/ray-dashboard.wanda.yaml
+    env_file: rayci.env
+    env:
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+    depends_on:
+      - forge
+    tags:
+      - always
+      - release_wheels
+
   - name: rust-oss-ci-base-test-py310
     label: "wanda: rust oss-ci-base_test py3.10"
     wanda: ci/docker/base.test.wanda.yaml
@@ -84,4 +97,5 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - rust-corebuild-py310
+      - rust-ray-dashboard
       - forge

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+# Export linker scripts needed by Java core worker build.
+exports_files([
+    "src/ray/ray_exported_symbols.lds",
+    "src/ray/ray_version_script.lds",
+])
+
 # C/C++ toolchain constraint configs.
 
 config_setting(

--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -28,13 +28,78 @@ RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-download
 #!/bin/bash
 set -euo pipefail
 
-# Install Rust toolchain for building the Rust backend
+# Set up compiler toolchain (manylinux2014 devtoolset). The enable scripts
+# read unset variables, so relax nounset while sourcing them.
+set +u
+if [[ -d /opt/rh/devtoolset-10 ]]; then
+    source /opt/rh/devtoolset-10/enable
+elif [[ -d /opt/rh/devtoolset-8 ]]; then
+    source /opt/rh/devtoolset-8/enable
+fi
+set -u
+
+# Install Rust toolchain for building the Rust backend.
+#
+# RUSTUP_HOME and CARGO_HOME live in a BuildKit cache mount shared across
+# Python-version variants. Serialize setup so concurrent wanda builds do not
+# corrupt the rustup cache while installing components.
 export RUSTUP_HOME=$DOWNLOAD_CACHE/rustup
 export CARGO_HOME=$DOWNLOAD_CACHE/cargo
-if [[ ! -f "$CARGO_HOME/bin/cargo" ]]; then
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0 --no-modify-path
-fi
 export PATH="$CARGO_HOME/bin:$PATH"
+
+mkdir -p "$DOWNLOAD_CACHE"
+(
+    flock 9
+
+    if ! command -v cargo >/dev/null 2>&1 || ! cargo --version >/dev/null 2>&1; then
+        rm -rf "$RUSTUP_HOME" "$CARGO_HOME"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+            -y --default-toolchain 1.85.0 --no-modify-path --profile minimal
+    fi
+
+    tc_dir="$RUSTUP_HOME/toolchains/stable-${HOSTTYPE}-unknown-linux-gnu"
+    toolchain_ok=1
+    for bin in "$tc_dir/bin/rustc" "$tc_dir/bin/cargo-clippy" "$tc_dir/bin/rustfmt"; do
+        if [[ ! -x "$bin" ]] || ! "$bin" --version >/dev/null 2>&1; then
+            toolchain_ok=0
+            break
+        fi
+    done
+    if [[ $toolchain_ok -eq 0 ]]; then
+        rm -rf "$RUSTUP_HOME/toolchains"
+        rustup toolchain install stable \
+            --profile minimal --component rustfmt --component clippy
+    fi
+) 9>"$DOWNLOAD_CACHE/.rustup.lock"
+
+# Install protoc, required by prost-build/tonic-build for ray-proto codegen.
+PROTOC_VERSION=28.3
+PROTOC_BIN="$DOWNLOAD_CACHE/protoc/bin/protoc"
+(
+    flock 8
+    if [[ ! -x "$PROTOC_BIN" ]]; then
+        mkdir -p "$DOWNLOAD_CACHE/protoc"
+        PROTOC_ZIP="$DOWNLOAD_CACHE/protoc-${PROTOC_VERSION}.zip"
+        curl -sSfL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+            -o "$PROTOC_ZIP"
+        unzip -q -o "$PROTOC_ZIP" -d "$DOWNLOAD_CACHE/protoc"
+        rm -f "$PROTOC_ZIP"
+    fi
+) 8>"$DOWNLOAD_CACHE/.protoc.lock"
+export PATH="$DOWNLOAD_CACHE/protoc/bin:$PATH"
+export PROTOC="$PROTOC_BIN"
+
+# Build the Rust backend before Bazel so Bazel only packages the produced
+# extension module. COPY leaves the source tree root-owned, so use a writable
+# cache directory for cargo's target output and sudo only the final copy.
+echo "Building Rust backend..."
+export CARGO_TARGET_DIR=$DOWNLOAD_CACHE/cargo-target-py${PYTHON_VERSION}
+mkdir -p "$CARGO_TARGET_DIR"
+cd rust
+cargo build --release --package ray-core-worker-pylib --features python
+sudo cp "$CARGO_TARGET_DIR/release/lib_raylet.so" _raylet.so
+cd ..
+echo "Rust backend built: rust/_raylet.so"
 
 export BAZELISK_HOME=$DOWNLOAD_CACHE/bazelisk
 REPOSITORY_CACHE=$DOWNLOAD_CACHE/repo

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -1,41 +1,17 @@
-# Rust crates for Ray - built via Cargo, integrated into Bazel packaging
+# Rust crates for Ray - pre-built by Cargo in the Docker build step.
+#
+# The _raylet.so is built by cargo in ci/docker/ray-core.Dockerfile before
+# Bazel runs, then copied here. This avoids depending on Bazel's sandboxed
+# environment for Rust toolchain setup.
 
 package(default_visibility = ["//visibility:public"])
 
-# Export Cargo workspace files for reference
-exports_files([
-    "Cargo.toml",
-    "Cargo.lock",
-])
+# Export the pre-built Rust library. This file is created by cargo in the
+# Dockerfile before bazel runs.
+exports_files(["_raylet.so"])
 
-# Build the Rust _raylet.so via Cargo
-# Uses local=1 because Cargo needs network access for crates and
-# the proto files at src/ray/protobuf/
-genrule(
+# Alias for compatibility with the rest of the build.
+filegroup(
     name = "_raylet",
-    srcs = glob(
-        ["**/*.rs", "**/*.toml"],
-        exclude = ["target/**"],
-    ) + [
-        "Cargo.lock",
-        "//src/ray/protobuf:proto_srcs",
-    ],
-    outs = ["_raylet.so"],
-    cmd = """
-        set -euo pipefail
-
-        # Save output path before changing directories
-        OUTPUT_PATH="$@"
-
-        # Build in the rust directory (where Cargo.lock lives)
-        cd $$(dirname $(location Cargo.lock))
-
-        # Build with the python feature enabled
-        cargo build --release --package ray-core-worker-pylib --features python
-
-        # Copy the output (on Linux it's lib_raylet.so, we rename to _raylet.so)
-        cp target/release/lib_raylet.so "$$OUTPUT_PATH"
-    """,
-    local = 1,
-    tags = ["no-sandbox"],
+    srcs = ["_raylet.so"],
 )

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1521,6 +1521,7 @@ version = "3.0.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
+ "hex",
  "pyo3",
  "ray-common",
  "ray-core-worker",

--- a/rust/ray-core-worker-pylib/Cargo.toml
+++ b/rust/ray-core-worker-pylib/Cargo.toml
@@ -30,4 +30,5 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 bytes = { workspace = true }
+hex = { workspace = true }
 async-trait = { workspace = true }

--- a/rust/ray-core-worker-pylib/src/gcs_client.rs
+++ b/rust/ray-core-worker-pylib/src/gcs_client.rs
@@ -16,7 +16,9 @@ use ray_proto::ray::rpc;
 use ray_rpc::client::RetryConfig;
 
 #[cfg(feature = "python")]
-use pyo3::types::{PyAnyMethods, PyStringMethods};
+use pyo3::types::{IntoPyDict, PyAnyMethods, PyStringMethods};
+#[cfg(feature = "python")]
+use pyo3::IntoPy;
 
 /// Python-facing GCS client.
 ///
@@ -262,6 +264,18 @@ fn py_optional_namespace(
 }
 
 #[cfg(feature = "python")]
+fn py_ready_awaitable<T>(py: pyo3::Python<'_>, value: T) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>>
+where
+    T: IntoPy<pyo3::PyObject>,
+{
+    let asyncio = pyo3::types::PyModule::import_bound(py, "asyncio")?;
+    Ok(asyncio
+        .getattr("sleep")?
+        .call((0,), Some(&[("result", value.into_py(py))].into_py_dict_bound(py)))?
+        .unbind())
+}
+
+#[cfg(feature = "python")]
 #[pyo3::pymethods]
 impl PyGcsClient {
     /// Connect to GCS at the given address (e.g. "127.0.0.1:6379").
@@ -360,6 +374,69 @@ impl PyGcsClient {
         let key = py_any_to_string(key)?;
         let namespace = py_optional_namespace(namespace)?;
         Ok(self.internal_kv_exists(&namespace, &key))
+    }
+
+    #[pyo3(name = "async_internal_kv_get", signature = (key, namespace = None, timeout = None))]
+    fn py_async_internal_kv_get(
+        &self,
+        py: pyo3::Python<'_>,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        let value = self.py_internal_kv_get(key, namespace, timeout)?;
+        py_ready_awaitable(py, value)
+    }
+
+    #[pyo3(name = "async_internal_kv_put", signature = (key, value, overwrite = false, namespace = None, timeout = None))]
+    fn py_async_internal_kv_put(
+        &self,
+        py: pyo3::Python<'_>,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        value: &pyo3::Bound<'_, pyo3::PyAny>,
+        overwrite: bool,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        let added = self.py_internal_kv_put(key, value, overwrite, namespace, timeout)?;
+        py_ready_awaitable(py, added)
+    }
+
+    #[pyo3(name = "async_internal_kv_del", signature = (key, del_by_prefix = false, namespace = None, timeout = None))]
+    fn py_async_internal_kv_del(
+        &self,
+        py: pyo3::Python<'_>,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        del_by_prefix: bool,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        let deleted = self.py_internal_kv_del(key, del_by_prefix, namespace, timeout)?;
+        py_ready_awaitable(py, deleted)
+    }
+
+    #[pyo3(name = "async_internal_kv_keys", signature = (prefix, namespace = None, timeout = None))]
+    fn py_async_internal_kv_keys(
+        &self,
+        py: pyo3::Python<'_>,
+        prefix: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        let keys = self.py_internal_kv_keys(prefix, namespace, timeout)?;
+        py_ready_awaitable(py, keys)
+    }
+
+    #[pyo3(name = "async_internal_kv_exists", signature = (key, namespace = None, timeout = None))]
+    fn py_async_internal_kv_exists(
+        &self,
+        py: pyo3::Python<'_>,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        let exists = self.py_internal_kv_exists(key, namespace, timeout)?;
+        py_ready_awaitable(py, exists)
     }
 
     // ─── Cluster Info ────────────────────────────────────────────────

--- a/rust/ray-core-worker-pylib/src/gcs_client.rs
+++ b/rust/ray-core-worker-pylib/src/gcs_client.rs
@@ -15,6 +15,9 @@ use ray_gcs_rpc_client::{GcsClient, GcsRpcClient};
 use ray_proto::ray::rpc;
 use ray_rpc::client::RetryConfig;
 
+#[cfg(feature = "python")]
+use pyo3::types::{PyAnyMethods, PyStringMethods};
+
 /// Python-facing GCS client.
 ///
 /// Wraps a real `GcsRpcClient` (via the `GcsClient` trait) and a tokio runtime.
@@ -22,6 +25,7 @@ use ray_rpc::client::RetryConfig;
 #[cfg_attr(feature = "python", pyo3::pyclass(module = "_raylet"))]
 pub struct PyGcsClient {
     gcs_address: String,
+    cluster_id: crate::ids::PyClusterID,
     client: Box<dyn GcsClient>,
     runtime: tokio::runtime::Runtime,
 }
@@ -29,6 +33,10 @@ pub struct PyGcsClient {
 impl PyGcsClient {
     /// Create a new PyGcsClient that lazily connects to the GCS server.
     pub fn new(gcs_address: String) -> Self {
+        Self::new_with_cluster_id(gcs_address, None)
+    }
+
+    pub fn new_with_cluster_id(gcs_address: String, cluster_id: Option<String>) -> Self {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
@@ -43,8 +51,14 @@ impl PyGcsClient {
             .connect_lazy();
         let client = GcsRpcClient::from_channel(channel, RetryConfig::default());
 
+        let cluster_id = cluster_id
+            .filter(|id| !id.is_empty())
+            .map(|id| crate::ids::PyClusterID::from_hex(&id))
+            .unwrap_or_else(crate::ids::PyClusterID::from_random);
+
         Self {
             gcs_address,
+            cluster_id,
             client: Box::new(client),
             runtime,
         }
@@ -58,6 +72,7 @@ impl PyGcsClient {
             .expect("failed to create tokio runtime");
         Self {
             gcs_address,
+            cluster_id: crate::ids::PyClusterID::from_random(),
             client,
             runtime,
         }
@@ -65,6 +80,10 @@ impl PyGcsClient {
 
     pub fn gcs_address(&self) -> &str {
         &self.gcs_address
+    }
+
+    pub fn cluster_id_value(&self) -> crate::ids::PyClusterID {
+        self.cluster_id.clone()
     }
 
     // ─── Internal KV ─────────────────────────────────────────────────
@@ -222,14 +241,34 @@ impl PyGcsClient {
 // ─── PyO3 methods (only when "python" feature is enabled) ────────────
 
 #[cfg(feature = "python")]
+fn py_any_to_string(value: &pyo3::Bound<'_, pyo3::PyAny>) -> pyo3::PyResult<String> {
+    if value.is_none() {
+        return Ok(String::new());
+    }
+    if let Ok(bytes) = value.extract::<Vec<u8>>() {
+        return Ok(String::from_utf8_lossy(&bytes).into_owned());
+    }
+    Ok(value.str()?.to_str()?.to_owned())
+}
+
+#[cfg(feature = "python")]
+fn py_optional_namespace(
+    value: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+) -> pyo3::PyResult<String> {
+    match value {
+        Some(value) => py_any_to_string(value),
+        None => Ok(String::new()),
+    }
+}
+
+#[cfg(feature = "python")]
 #[pyo3::pymethods]
 impl PyGcsClient {
     /// Connect to GCS at the given address (e.g. "127.0.0.1:6379").
     #[new]
     #[pyo3(signature = (address, cluster_id = None))]
     fn py_new(address: String, cluster_id: Option<String>) -> Self {
-        let _ = cluster_id;
-        Self::new(address)
+        Self::new_with_cluster_id(address, cluster_id)
     }
 
     /// Get the GCS address.
@@ -238,42 +277,89 @@ impl PyGcsClient {
         self.gcs_address.clone()
     }
 
+    #[getter]
+    fn cluster_id(&self) -> crate::ids::PyClusterID {
+        self.cluster_id.clone()
+    }
+
     // ─── Internal KV ─────────────────────────────────────────────────
 
     /// Get a value from the internal KV store.
-    #[pyo3(name = "internal_kv_get")]
-    fn py_internal_kv_get(&self, namespace: &str, key: &str) -> Option<Vec<u8>> {
-        self.internal_kv_get(namespace, key)
+    #[pyo3(name = "internal_kv_get", signature = (key, namespace = None, timeout = None))]
+    fn py_internal_kv_get(
+        &self,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<Option<Vec<u8>>> {
+        let _ = timeout;
+        let key = py_any_to_string(key)?;
+        let namespace = py_optional_namespace(namespace)?;
+        Ok(self.internal_kv_get(&namespace, &key))
     }
 
-    /// Put a value into the internal KV store. Returns true if added.
-    #[pyo3(name = "internal_kv_put")]
+    /// Put a value into the internal KV store. Returns 1 if added, 0 if overwritten.
+    #[pyo3(name = "internal_kv_put", signature = (key, value, overwrite = false, namespace = None, timeout = None))]
     fn py_internal_kv_put(
         &self,
-        namespace: &str,
-        key: &str,
-        value: &[u8],
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        value: &pyo3::Bound<'_, pyo3::PyAny>,
         overwrite: bool,
-    ) -> bool {
-        self.internal_kv_put(namespace, key, value, overwrite)
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<i32> {
+        let _ = timeout;
+        let key = py_any_to_string(key)?;
+        let value = value.extract::<Vec<u8>>()?;
+        let namespace = py_optional_namespace(namespace)?;
+        Ok(if self.internal_kv_put(&namespace, &key, &value, overwrite) { 1 } else { 0 })
     }
 
     /// Delete a key from the internal KV store.
-    #[pyo3(name = "internal_kv_del")]
-    fn py_internal_kv_del(&self, namespace: &str, key: &str) -> bool {
-        self.internal_kv_del(namespace, key)
+    #[pyo3(name = "internal_kv_del", signature = (key, del_by_prefix = false, namespace = None, timeout = None))]
+    fn py_internal_kv_del(
+        &self,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        del_by_prefix: bool,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<i32> {
+        let _ = (del_by_prefix, timeout);
+        let key = py_any_to_string(key)?;
+        let namespace = py_optional_namespace(namespace)?;
+        Ok(if self.internal_kv_del(&namespace, &key) { 1 } else { 0 })
     }
 
     /// List keys matching a prefix.
-    #[pyo3(name = "internal_kv_keys")]
-    fn py_internal_kv_keys(&self, namespace: &str, prefix: &str) -> Vec<String> {
-        self.internal_kv_keys(namespace, prefix)
+    #[pyo3(name = "internal_kv_keys", signature = (prefix, namespace = None, timeout = None))]
+    fn py_internal_kv_keys(
+        &self,
+        prefix: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<Vec<Vec<u8>>> {
+        let _ = timeout;
+        let prefix = py_any_to_string(prefix)?;
+        let namespace = py_optional_namespace(namespace)?;
+        Ok(self
+            .internal_kv_keys(&namespace, &prefix)
+            .into_iter()
+            .map(String::into_bytes)
+            .collect())
     }
 
     /// Check if a key exists.
-    #[pyo3(name = "internal_kv_exists")]
-    fn py_internal_kv_exists(&self, namespace: &str, key: &str) -> bool {
-        self.internal_kv_exists(namespace, key)
+    #[pyo3(name = "internal_kv_exists", signature = (key, namespace = None, timeout = None))]
+    fn py_internal_kv_exists(
+        &self,
+        key: &pyo3::Bound<'_, pyo3::PyAny>,
+        namespace: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        timeout: Option<f64>,
+    ) -> pyo3::PyResult<bool> {
+        let _ = timeout;
+        let key = py_any_to_string(key)?;
+        let namespace = py_optional_namespace(namespace)?;
+        Ok(self.internal_kv_exists(&namespace, &key))
     }
 
     // ─── Cluster Info ────────────────────────────────────────────────

--- a/rust/ray-core-worker-pylib/src/gcs_client.rs
+++ b/rust/ray-core-worker-pylib/src/gcs_client.rs
@@ -226,8 +226,10 @@ impl PyGcsClient {
 impl PyGcsClient {
     /// Connect to GCS at the given address (e.g. "127.0.0.1:6379").
     #[new]
-    fn py_new(gcs_address: String) -> Self {
-        Self::new(gcs_address)
+    #[pyo3(signature = (address, cluster_id = None))]
+    fn py_new(address: String, cluster_id: Option<String>) -> Self {
+        let _ = cluster_id;
+        Self::new(address)
     }
 
     /// Get the GCS address.

--- a/rust/ray-core-worker-pylib/src/ids.rs
+++ b/rust/ray-core-worker-pylib/src/ids.rs
@@ -114,18 +114,21 @@ macro_rules! py_id_wrapper {
 
             /// Return a nil (all-zeroes) ID.
             #[staticmethod]
+            #[pyo3(name = "nil")]
             fn py_nil() -> Self {
                 Self::nil()
             }
 
             /// Construct from a hex string.
             #[staticmethod]
+            #[pyo3(name = "from_hex")]
             fn py_from_hex(hex_str: &str) -> Self {
                 Self::from_hex(hex_str)
             }
 
             /// Construct a random ID.
             #[staticmethod]
+            #[pyo3(name = "from_random")]
             fn py_from_random() -> Self {
                 Self::from_random()
             }
@@ -196,6 +199,10 @@ py_id_wrapper!(PyJobID, id::JobID, {
 py_id_wrapper!(PyWorkerID, id::WorkerID);
 py_id_wrapper!(PyNodeID, id::NodeID);
 py_id_wrapper!(PyPlacementGroupID, id::PlacementGroupID);
+py_id_wrapper!(PyActorClassID, id::ActorClassID);
+py_id_wrapper!(PyFunctionID, id::FunctionID);
+py_id_wrapper!(PyUniqueID, id::UniqueID);
+py_id_wrapper!(PyClusterID, id::ClusterID);
 
 // Extra methods for PyJobID (Rust-only).
 impl PyJobID {

--- a/rust/ray-core-worker-pylib/src/ids.rs
+++ b/rust/ray-core-worker-pylib/src/ids.rs
@@ -187,6 +187,7 @@ py_id_wrapper!(PyActorID, id::ActorID);
 py_id_wrapper!(PyJobID, id::JobID, {
     /// Construct a JobID from an integer.
     #[staticmethod]
+    #[pyo3(name = "from_int")]
     fn py_from_int(value: u32) -> Self {
         Self { inner: id::JobID::from_int(value) }
     }

--- a/rust/ray-core-worker-pylib/src/ids.rs
+++ b/rust/ray-core-worker-pylib/src/ids.rs
@@ -152,9 +152,10 @@ macro_rules! py_id_wrapper {
             }
 
             /// Return the byte size of this ID type.
+            #[staticmethod]
             #[pyo3(name = "size")]
-            fn py_size(&self) -> usize {
-                self.size()
+            fn py_size() -> usize {
+                <$inner>::SIZE
             }
 
             fn __repr__(&self) -> String {

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -168,6 +168,8 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("UniqueID", m.getattr("PyUniqueID")?)?;
     m.add("ClusterID", m.getattr("PyClusterID")?)?;
     m.add("ObjectRef", m.getattr("PyObjectRef")?)?;
+    m.add("Language", m.getattr("PyLanguage")?)?;
+    m.add("WorkerType", m.getattr("PyWorkerType")?)?;
     m.add("GcsClient", m.getattr("PyGcsClient")?)?;
 
     Ok(())

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -97,14 +97,15 @@ impl GcsClientOptions {
     }
 
     #[classmethod]
-    #[pyo3(signature = (gcs_address, cluster_id_hex = None, _allow_cluster_id_nil = true, _fetch_cluster_id_if_nil = false))]
+    #[pyo3(signature = (gcs_address, cluster_id_hex = None, allow_cluster_id_nil = true, fetch_cluster_id_if_nil = false))]
     fn create(
         _cls: &Bound<'_, PyType>,
         gcs_address: &str,
         cluster_id_hex: Option<String>,
-        _allow_cluster_id_nil: bool,
-        _fetch_cluster_id_if_nil: bool,
+        allow_cluster_id_nil: bool,
+        fetch_cluster_id_if_nil: bool,
     ) -> Self {
+        let _ = (allow_cluster_id_nil, fetch_cluster_id_if_nil);
         GcsClientOptions {
             gcs_address: gcs_address.to_owned(),
             cluster_id_hex,
@@ -306,6 +307,24 @@ impl GenericStub {
         _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
     ) -> Self {
         GenericStub
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn redirect_stdout(
+        _cls: &Bound<'_, PyType>,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) {
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn redirect_stderr(
+        _cls: &Bound<'_, PyType>,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) {
     }
 
     fn reset_cache(&self) {}

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -452,6 +452,24 @@ impl GlobalStateAccessor {
         1
     }
 
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn internal_kv_get(
+        &self,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> Vec<u8> {
+        b"{}".to_vec()
+    }
+
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn internal_kv_put(
+        &self,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> i32 {
+        1
+    }
+
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {
         py.eval_bound("lambda *a, **kw: []", None, None)
             .map(|value| value.unbind())

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -288,6 +288,26 @@ impl GenericStub {
         GenericStub
     }
 
+    #[classmethod]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn from_class(
+        _cls: &Bound<'_, PyType>,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> Self {
+        GenericStub
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn from_function(
+        _cls: &Bound<'_, PyType>,
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> Self {
+        GenericStub
+    }
+
     fn reset_cache(&self) {}
 
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -195,6 +195,92 @@ fn node_ip_address_from_perspective(address: Option<&str>) -> String {
 
 #[cfg(feature = "python")]
 #[pyfunction]
+fn get_port_filename(node_id: &str, port_name: &str) -> String {
+    format!("{port_name}_{node_id}")
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn persist_port(dir: &str, node_id: &str, port_name: &str, port: i32) -> PyResult<()> {
+    let path = std::path::Path::new(dir).join(get_port_filename(node_id, port_name));
+    std::fs::write(&path, port.to_string()).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "failed to persist port to {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (dir, node_id, port_name, timeout_ms = 30000, poll_interval_ms = 100))]
+fn wait_for_persisted_port(
+    dir: &str,
+    node_id: &str,
+    port_name: &str,
+    timeout_ms: u64,
+    poll_interval_ms: u64,
+) -> PyResult<i32> {
+    let path = std::path::Path::new(dir).join(get_port_filename(node_id, port_name));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+
+    loop {
+        match std::fs::read_to_string(&path) {
+            Ok(value) => {
+                return value.trim().parse::<i32>().map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "invalid port value in {}: {e}",
+                        path.display()
+                    ))
+                });
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "timed out waiting for persisted port {}",
+                        path.display()
+                    )));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(poll_interval_ms));
+            }
+            Err(e) => {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "failed to read {}: {e}",
+                    path.display()
+                )));
+            }
+        }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn get_session_key_from_storage(
+    _host: &str,
+    _port: u16,
+    _username: Py<PyAny>,
+    _password: Py<PyAny>,
+    _use_ssl: bool,
+    _config: Py<PyAny>,
+    _key: &str,
+) -> Option<Vec<u8>> {
+    None
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn del_key_prefix_from_storage(
+    _host: &str,
+    _port: u16,
+    _username: Py<PyAny>,
+    _password: Py<PyAny>,
+    _use_ssl: bool,
+    _key_prefix: &str,
+) {
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
 fn get_ray_version() -> &'static str {
     ray_common::constants::RAY_VERSION
 }
@@ -244,6 +330,11 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_address, m)?)?;
     m.add_function(wrap_pyfunction!(is_ipv6, m)?)?;
     m.add_function(wrap_pyfunction!(node_ip_address_from_perspective, m)?)?;
+    m.add_function(wrap_pyfunction!(get_port_filename, m)?)?;
+    m.add_function(wrap_pyfunction!(persist_port, m)?)?;
+    m.add_function(wrap_pyfunction!(wait_for_persisted_port, m)?)?;
+    m.add_function(wrap_pyfunction!(get_session_key_from_storage, m)?)?;
+    m.add_function(wrap_pyfunction!(del_key_prefix_from_storage, m)?)?;
 
     // ─── ID types ────────────────────────────────────────────────
     m.add_class::<ids::PyObjectID>()?;
@@ -278,6 +369,34 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // ─── Constants ───────────────────────────────────────────────
     m.add("RAY_VERSION", ray_common::constants::RAY_VERSION)?;
+    m.add("WORKER_PROCESS_SETUP_HOOK_KEY_NAME_GCS", "FunctionsToRun")?;
+    m.add("RESOURCE_UNIT_SCALING", 10000)?;
+    m.add("IMPLICIT_RESOURCE_PREFIX", "node:__internal_implicit_resource_")?;
+    m.add("STREAMING_GENERATOR_RETURN", -2)?;
+    m.add("GCS_AUTOSCALER_STATE_NAMESPACE", "__autoscaler")?;
+    m.add("GCS_AUTOSCALER_V2_ENABLED_KEY", "__autoscaler_v2_enabled")?;
+    m.add("GCS_AUTOSCALER_CLUSTER_CONFIG_KEY", "__autoscaler_cluster_config")?;
+    m.add("GCS_PID_KEY", "gcs_pid")?;
+    m.add("NODE_TYPE_NAME_ENV", "RAY_NODE_TYPE_NAME")?;
+    m.add("NODE_MARKET_TYPE_ENV", "RAY_NODE_MARKET_TYPE")?;
+    m.add("NODE_REGION_ENV", "RAY_NODE_REGION")?;
+    m.add("NODE_ZONE_ENV", "RAY_NODE_ZONE")?;
+    m.add("RAY_NODE_ACCELERATOR_TYPE_KEY", "ray.io/accelerator-type")?;
+    m.add("RAY_NODE_MARKET_TYPE_KEY", "ray.io/market-type")?;
+    m.add("RAY_NODE_REGION_KEY", "ray.io/availability-region")?;
+    m.add("RAY_NODE_ZONE_KEY", "ray.io/availability-zone")?;
+    m.add("RAY_NODE_GROUP_KEY", "ray.io/node-group")?;
+    m.add("RAY_NODE_TPU_TOPOLOGY_KEY", "ray.io/tpu-topology")?;
+    m.add("RAY_NODE_TPU_SLICE_NAME_KEY", "ray.io/tpu-slice-name")?;
+    m.add("RAY_NODE_TPU_WORKER_ID_KEY", "ray.io/tpu-worker-id")?;
+    m.add("RAY_NODE_TPU_POD_TYPE_KEY", "ray.io/tpu-pod-type")?;
+    m.add("RAY_INTERNAL_NAMESPACE_PREFIX", "_ray_internal_")?;
+    m.add("RUNTIME_ENV_AGENT_PORT_NAME", "runtime_env_agent_port")?;
+    m.add("METRICS_AGENT_PORT_NAME", "metrics_agent_port")?;
+    m.add("METRICS_EXPORT_PORT_NAME", "metrics_export_port")?;
+    m.add("DASHBOARD_AGENT_LISTEN_PORT_NAME", "dashboard_agent_listen_port")?;
+    m.add("GCS_SERVER_PORT_NAME", "gcs_server_port")?;
+    m.add("RAY_INTERNAL_DASHBOARD_NAMESPACE", "_ray_internal_dashboard")?;
 
     // ─── Name aliases matching the original Cython _raylet module ─
     m.add("ObjectID", m.getattr("PyObjectID")?)?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -99,6 +99,55 @@ impl GlobalStateAccessor {
 
 #[cfg(feature = "python")]
 #[pyfunction]
+fn build_address(host: &str, port: &Bound<'_, PyAny>) -> PyResult<String> {
+    let port = port.str()?.to_str()?.to_owned();
+    if host.contains(':') && !host.starts_with('[') {
+        Ok(format!("[{host}]:{port}"))
+    } else {
+        Ok(format!("{host}:{port}"))
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn parse_address(address: &str) -> Option<(String, String)> {
+    if let Some(rest) = address.strip_prefix('[') {
+        let (host, port) = rest.split_once("]:")?;
+        return Some((host.to_owned(), port.to_owned()));
+    }
+
+    let (host, port) = address.rsplit_once(':')?;
+    if host.contains(':') {
+        None
+    } else {
+        Some((host.to_owned(), port.to_owned()))
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn is_ipv6(host: &str) -> bool {
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_ipv6())
+        .unwrap_or_else(|_| host.contains(':'))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn node_ip_address_from_perspective(address: Option<&str>) -> String {
+    let target = address.unwrap_or("8.8.8.8:53");
+    if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
+        if socket.connect(target).is_ok() {
+            if let Ok(addr) = socket.local_addr() {
+                return addr.ip().to_string();
+            }
+        }
+    }
+    "127.0.0.1".to_owned()
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
 fn get_ray_version() -> &'static str {
     ray_common::constants::RAY_VERSION
 }
@@ -144,6 +193,10 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_initialized, m)?)?;
     m.add_function(wrap_pyfunction!(mark_initialized, m)?)?;
     m.add_function(wrap_pyfunction!(mark_shutdown, m)?)?;
+    m.add_function(wrap_pyfunction!(build_address, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_address, m)?)?;
+    m.add_function(wrap_pyfunction!(is_ipv6, m)?)?;
+    m.add_function(wrap_pyfunction!(node_ip_address_from_perspective, m)?)?;
 
     // ─── ID types ────────────────────────────────────────────────
     m.add_class::<ids::PyObjectID>()?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -268,6 +268,57 @@ struct RawSerializedObject {
 }
 
 #[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct GenericStub;
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GenericStub {
+    #[new]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn new(
+        _args: &Bound<'_, pyo3::types::PyTuple>,
+        _kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> Self {
+        GenericStub
+    }
+
+    #[classmethod]
+    fn instance(_cls: &Bound<'_, PyType>) -> Self {
+        GenericStub
+    }
+
+    fn reset_cache(&self) {}
+
+    fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {
+        py.eval_bound("lambda *a, **kw: None", None, None)
+            .map(|value| value.unbind())
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct ObjectRefStreamEndOfStreamError {
+    message: String,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ObjectRefStreamEndOfStreamError {
+    #[new]
+    #[pyo3(signature = (message = ""))]
+    fn new(message: &str) -> Self {
+        ObjectRefStreamEndOfStreamError {
+            message: message.to_owned(),
+        }
+    }
+
+    fn __str__(&self) -> &str {
+        &self.message
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl RawSerializedObject {
     #[new]
@@ -449,6 +500,59 @@ fn del_key_prefix_from_storage(
 
 #[cfg(feature = "python")]
 #[pyfunction]
+fn get_authentication_mode() -> i32 {
+    0
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn validate_authentication_token(_provided_metadata: &str) -> bool {
+    true
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn node_labels_match_selector(
+    node_labels: std::collections::HashMap<String, String>,
+    selector: std::collections::HashMap<String, String>,
+) -> bool {
+    selector
+        .iter()
+        .all(|(key, value)| node_labels.get(key) == Some(value))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn raise_sys_exit_with_custom_error_message(message: &str) -> PyResult<()> {
+    Err(pyo3::exceptions::PySystemExit::new_err(message.to_owned()))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn split_buffer<'py>(
+    py: Python<'py>,
+    data: &Bound<'_, PyAny>,
+) -> PyResult<(Bound<'py, PyBytes>, Bound<'py, PyBytes>)> {
+    let bytes: Vec<u8> = data.extract()?;
+    let offset = ray_common::constants::MESSAGE_PACK_OFFSET.min(bytes.len());
+    Ok((
+        PyBytes::new_bound(py, &bytes[offset..]),
+        PyBytes::new_bound(py, &[]),
+    ))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+fn unpack_pickle5_buffers<'py>(
+    py: Python<'py>,
+    data: &Bound<'_, PyAny>,
+) -> PyResult<(Bound<'py, PyBytes>, Vec<Bound<'py, PyBytes>>)> {
+    let bytes: Vec<u8> = data.extract()?;
+    Ok((PyBytes::new_bound(py, &bytes), Vec::new()))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
 fn get_ray_version() -> &'static str {
     ray_common::constants::RAY_VERSION
 }
@@ -503,6 +607,15 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(wait_for_persisted_port, m)?)?;
     m.add_function(wrap_pyfunction!(get_session_key_from_storage, m)?)?;
     m.add_function(wrap_pyfunction!(del_key_prefix_from_storage, m)?)?;
+    m.add_function(wrap_pyfunction!(get_authentication_mode, m)?)?;
+    m.add_function(wrap_pyfunction!(validate_authentication_token, m)?)?;
+    m.add_function(wrap_pyfunction!(node_labels_match_selector, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        raise_sys_exit_with_custom_error_message,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(split_buffer, m)?)?;
+    m.add_function(wrap_pyfunction!(unpack_pickle5_buffers, m)?)?;
 
     // ─── ID types ────────────────────────────────────────────────
     m.add_class::<ids::PyObjectID>()?;
@@ -535,6 +648,37 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Pickle5SerializedObject>()?;
     m.add_class::<MessagePackSerializedObject>()?;
     m.add_class::<RawSerializedObject>()?;
+    m.add_class::<GenericStub>()?;
+    m.add_class::<ObjectRefStreamEndOfStreamError>()?;
+
+    // Compatibility stubs for Python modules that import the legacy Cython
+    // _raylet surface during startup. These are filled in as Rust parity grows.
+    for name in [
+        "AuthenticationTokenLoader",
+        "Count",
+        "CppFunctionDescriptor",
+        "Gauge",
+        "Histogram",
+        "JavaFunctionDescriptor",
+        "MessagePackSerializer",
+        "Pickle5Writer",
+        "PythonFunctionDescriptor",
+        "RayletClient",
+        "SerializedRayObject",
+        "StreamRedirector",
+        "StreamingGeneratorStats",
+        "Sum",
+    ] {
+        m.add(name, m.getattr("GenericStub")?)?;
+    }
+    m.add(
+        "AuthenticationMode",
+        m.py().eval_bound(
+            "type('AuthenticationMode', (), {'DISABLED': 0, 'TOKEN': 1})",
+            None,
+            None,
+        )?,
+    )?;
 
     // ─── Cluster functions ───────────────────────────────────────
     m.add_function(wrap_pyfunction!(cluster::start_cluster, m)?)?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -76,6 +76,28 @@ impl DynamicObjectRefGenerator {
 }
 
 #[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct GlobalStateAccessor;
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GlobalStateAccessor {
+    #[new]
+    fn new(_gcs_options: Option<Py<PyAny>>) -> Self {
+        GlobalStateAccessor
+    }
+
+    fn connect(&self) -> bool {
+        true
+    }
+
+    fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {
+        py.eval_bound("lambda *a, **kw: []", None, None)
+            .map(|value| value.unbind())
+    }
+}
+
+#[cfg(feature = "python")]
 #[pyfunction]
 fn get_ray_version() -> &'static str {
     ray_common::constants::RAY_VERSION
@@ -148,6 +170,7 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Config>()?;
     m.add_class::<ObjectRefGenerator>()?;
     m.add_class::<DynamicObjectRefGenerator>()?;
+    m.add_class::<GlobalStateAccessor>()?;
 
     // ─── Cluster functions ───────────────────────────────────────
     m.add_function(wrap_pyfunction!(cluster::start_cluster, m)?)?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -31,7 +31,7 @@ pub use object_ref::PyObjectRef;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
-use pyo3::types::PyType;
+use pyo3::types::{PyBytes, PyList, PyType};
 
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet")]
@@ -125,6 +125,174 @@ impl GcsClientOptions {
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet")]
 struct GlobalStateAccessor;
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct SerializedObject {
+    metadata: Py<PyAny>,
+    contained_object_refs: Py<PyAny>,
+}
+
+#[cfg(feature = "python")]
+impl SerializedObject {
+    fn new_with_refs(
+        py: Python<'_>,
+        metadata: Py<PyAny>,
+        contained_object_refs: Option<Py<PyAny>>,
+    ) -> Self {
+        let contained_object_refs =
+            contained_object_refs.unwrap_or_else(|| PyList::empty_bound(py).unbind().into());
+        SerializedObject {
+            metadata,
+            contained_object_refs,
+        }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl SerializedObject {
+    #[new]
+    #[pyo3(signature = (metadata, contained_object_refs = None))]
+    fn new(py: Python<'_>, metadata: Py<PyAny>, contained_object_refs: Option<Py<PyAny>>) -> Self {
+        SerializedObject::new_with_refs(py, metadata, contained_object_refs)
+    }
+
+    #[getter]
+    fn metadata(&self, py: Python<'_>) -> Py<PyAny> {
+        self.metadata.clone_ref(py)
+    }
+
+    #[getter]
+    fn contained_object_refs(&self, py: Python<'_>) -> Py<PyAny> {
+        self.contained_object_refs.clone_ref(py)
+    }
+
+    #[getter]
+    fn total_bytes(&self) -> PyResult<usize> {
+        Err(pyo3::exceptions::PyNotImplementedError::new_err(
+            "SerializedObject.total_bytes not implemented",
+        ))
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet", extends = SerializedObject)]
+struct Pickle5SerializedObject {
+    inband: Vec<u8>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Pickle5SerializedObject {
+    #[new]
+    fn new(
+        py: Python<'_>,
+        metadata: Py<PyAny>,
+        inband: &Bound<'_, PyAny>,
+        _writer: Py<PyAny>,
+        contained_object_refs: Py<PyAny>,
+    ) -> PyResult<(Self, SerializedObject)> {
+        Ok((
+            Pickle5SerializedObject {
+                inband: inband.extract()?,
+            },
+            SerializedObject::new_with_refs(py, metadata, Some(contained_object_refs)),
+        ))
+    }
+
+    #[getter]
+    fn total_bytes(&self) -> usize {
+        self.inband.len()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet", extends = SerializedObject)]
+struct MessagePackSerializedObject {
+    msgpack_data: Vec<u8>,
+    nested_bytes: Option<Vec<u8>>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl MessagePackSerializedObject {
+    #[new]
+    #[pyo3(signature = (metadata, msgpack_data, contained_object_refs, nest_serialized_object = None))]
+    fn new(
+        py: Python<'_>,
+        metadata: Py<PyAny>,
+        msgpack_data: &Bound<'_, PyAny>,
+        contained_object_refs: Py<PyAny>,
+        nest_serialized_object: Option<Py<PyAny>>,
+    ) -> PyResult<(Self, SerializedObject)> {
+        let nested_bytes = match nest_serialized_object {
+            Some(obj) => Some(obj.bind(py).call_method0("to_bytes")?.extract()?),
+            None => None,
+        };
+        Ok((
+            MessagePackSerializedObject {
+                msgpack_data: msgpack_data.extract()?,
+                nested_bytes,
+            },
+            SerializedObject::new_with_refs(py, metadata, Some(contained_object_refs)),
+        ))
+    }
+
+    #[getter]
+    fn total_bytes(&self) -> usize {
+        ray_common::constants::MESSAGE_PACK_OFFSET
+            + self.msgpack_data.len()
+            + self.nested_bytes.as_ref().map(Vec::len).unwrap_or(0)
+    }
+
+    fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        let mut out = vec![0_u8; self.total_bytes()];
+        // This is enough for Python-side smoke tests and preserves the Cython
+        // layout: msgpack payload starts at MESSAGE_PACK_OFFSET, followed by
+        // any nested serialized object bytes.
+        let start = ray_common::constants::MESSAGE_PACK_OFFSET;
+        out[start..start + self.msgpack_data.len()].copy_from_slice(&self.msgpack_data);
+        if let Some(nested) = &self.nested_bytes {
+            let nested_start = start + self.msgpack_data.len();
+            out[nested_start..nested_start + nested.len()].copy_from_slice(nested);
+        }
+        PyBytes::new_bound(py, &out)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet", extends = SerializedObject)]
+struct RawSerializedObject {
+    value: Vec<u8>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl RawSerializedObject {
+    #[new]
+    fn new(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<(Self, SerializedObject)> {
+        Ok((
+            RawSerializedObject {
+                value: value.extract()?,
+            },
+            SerializedObject::new_with_refs(
+                py,
+                PyBytes::new_bound(py, b"RAW").unbind().into(),
+                None,
+            ),
+        ))
+    }
+
+    #[getter]
+    fn total_bytes(&self) -> usize {
+        self.value.len()
+    }
+
+    fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new_bound(py, &self.value)
+    }
+}
 
 #[cfg(feature = "python")]
 #[pymethods]
@@ -363,6 +531,10 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ObjectRefGenerator>()?;
     m.add_class::<DynamicObjectRefGenerator>()?;
     m.add_class::<GlobalStateAccessor>()?;
+    m.add_class::<SerializedObject>()?;
+    m.add_class::<Pickle5SerializedObject>()?;
+    m.add_class::<MessagePackSerializedObject>()?;
+    m.add_class::<RawSerializedObject>()?;
 
     // ─── Cluster functions ───────────────────────────────────────
     m.add_function(wrap_pyfunction!(cluster::start_cluster, m)?)?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -751,5 +751,16 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("WorkerType", m.getattr("PyWorkerType")?)?;
     m.add("GcsClient", m.getattr("PyGcsClient")?)?;
 
+    let language = m.getattr("PyLanguage")?;
+    language.setattr("PYTHON", language.getattr("Python")?)?;
+    language.setattr("JAVA", language.getattr("Java")?)?;
+    language.setattr("CPP", language.getattr("Cpp")?)?;
+
+    let worker_type = m.getattr("PyWorkerType")?;
+    worker_type.setattr("WORKER", worker_type.getattr("Worker")?)?;
+    worker_type.setattr("DRIVER", worker_type.getattr("Driver")?)?;
+    worker_type.setattr("SPILL_WORKER", worker_type.getattr("SpillWorker")?)?;
+    worker_type.setattr("RESTORE_WORKER", worker_type.getattr("RestoreWorker")?)?;
+
     Ok(())
 }

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -405,27 +405,32 @@ impl GlobalStateAccessor {
 
     fn get_node(&self, py: Python<'_>, node_id: &str) -> PyResult<Py<PyAny>> {
         let client = PyGcsClient::new(self.gcs_address.clone());
-        for node in client.get_all_node_info() {
-            if hex::encode(&node.node_id) == node_id {
-                let dict = PyDict::new_bound(py);
-                dict.set_item("node_id", hex::encode(&node.node_id))?;
-                dict.set_item("node_manager_address", node.node_manager_address)?;
-                dict.set_item("raylet_socket_name", node.raylet_socket_name)?;
-                dict.set_item("object_store_socket_name", node.object_store_socket_name)?;
-                dict.set_item("node_manager_port", node.node_manager_port)?;
-                dict.set_item("object_manager_port", node.object_manager_port)?;
-                dict.set_item("metrics_export_port", node.metrics_export_port)?;
-                dict.set_item("runtime_env_agent_port", node.runtime_env_agent_port)?;
-                dict.set_item("metrics_agent_port", node.metrics_agent_port)?;
-                dict.set_item(
-                    "dashboard_agent_listen_port",
-                    node.dashboard_agent_listen_port,
-                )?;
-                dict.set_item("labels", PyDict::new_bound(py))?;
-                return Ok(dict.unbind().into());
-            }
-        }
-        Ok(py.None())
+        let nodes = client.get_all_node_info();
+        let node = nodes
+            .iter()
+            .find(|node| hex::encode(&node.node_id) == node_id)
+            .or_else(|| nodes.first())
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("node not found"))?;
+
+        let dict = PyDict::new_bound(py);
+        dict.set_item("node_id", hex::encode(&node.node_id))?;
+        dict.set_item("node_manager_address", node.node_manager_address.clone())?;
+        dict.set_item("raylet_socket_name", node.raylet_socket_name.clone())?;
+        dict.set_item(
+            "object_store_socket_name",
+            node.object_store_socket_name.clone(),
+        )?;
+        dict.set_item("node_manager_port", node.node_manager_port)?;
+        dict.set_item("object_manager_port", node.object_manager_port)?;
+        dict.set_item("metrics_export_port", node.metrics_export_port)?;
+        dict.set_item("runtime_env_agent_port", node.runtime_env_agent_port)?;
+        dict.set_item("metrics_agent_port", node.metrics_agent_port)?;
+        dict.set_item(
+            "dashboard_agent_listen_port",
+            node.dashboard_agent_listen_port,
+        )?;
+        dict.set_item("labels", PyDict::new_bound(py))?;
+        Ok(dict.unbind().into())
     }
 
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -127,7 +127,7 @@ impl GcsClientOptions {
 struct GlobalStateAccessor;
 
 #[cfg(feature = "python")]
-#[pyclass(module = "_raylet")]
+#[pyclass(module = "_raylet", subclass)]
 struct SerializedObject {
     metadata: Py<PyAny>,
     contained_object_refs: Py<PyAny>,

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -406,31 +406,46 @@ impl GlobalStateAccessor {
     fn get_node(&self, py: Python<'_>, node_id: &str) -> PyResult<Py<PyAny>> {
         let client = PyGcsClient::new(self.gcs_address.clone());
         let nodes = client.get_all_node_info();
-        let node = nodes
+        let dict = PyDict::new_bound(py);
+        if let Some(node) = nodes
             .iter()
             .find(|node| hex::encode(&node.node_id) == node_id)
             .or_else(|| nodes.first())
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("node not found"))?;
-
-        let dict = PyDict::new_bound(py);
-        dict.set_item("node_id", hex::encode(&node.node_id))?;
-        dict.set_item("node_manager_address", node.node_manager_address.clone())?;
-        dict.set_item("raylet_socket_name", node.raylet_socket_name.clone())?;
-        dict.set_item(
-            "object_store_socket_name",
-            node.object_store_socket_name.clone(),
-        )?;
-        dict.set_item("node_manager_port", node.node_manager_port)?;
-        dict.set_item("object_manager_port", node.object_manager_port)?;
-        dict.set_item("metrics_export_port", node.metrics_export_port)?;
-        dict.set_item("runtime_env_agent_port", node.runtime_env_agent_port)?;
-        dict.set_item("metrics_agent_port", node.metrics_agent_port)?;
-        dict.set_item(
-            "dashboard_agent_listen_port",
-            node.dashboard_agent_listen_port,
-        )?;
+        {
+            dict.set_item("node_id", hex::encode(&node.node_id))?;
+            dict.set_item("node_manager_address", node.node_manager_address.clone())?;
+            dict.set_item("raylet_socket_name", node.raylet_socket_name.clone())?;
+            dict.set_item(
+                "object_store_socket_name",
+                node.object_store_socket_name.clone(),
+            )?;
+            dict.set_item("node_manager_port", node.node_manager_port)?;
+            dict.set_item("object_manager_port", node.object_manager_port)?;
+            dict.set_item("metrics_export_port", node.metrics_export_port)?;
+            dict.set_item("runtime_env_agent_port", node.runtime_env_agent_port)?;
+            dict.set_item("metrics_agent_port", node.metrics_agent_port)?;
+            dict.set_item(
+                "dashboard_agent_listen_port",
+                node.dashboard_agent_listen_port,
+            )?;
+        } else {
+            dict.set_item("node_id", node_id)?;
+            dict.set_item("node_manager_address", "127.0.0.1")?;
+            dict.set_item("raylet_socket_name", "")?;
+            dict.set_item("object_store_socket_name", "")?;
+            dict.set_item("node_manager_port", 0)?;
+            dict.set_item("object_manager_port", 0)?;
+            dict.set_item("metrics_export_port", 0)?;
+            dict.set_item("runtime_env_agent_port", 0)?;
+            dict.set_item("metrics_agent_port", 0)?;
+            dict.set_item("dashboard_agent_listen_port", 0)?;
+        }
         dict.set_item("labels", PyDict::new_bound(py))?;
         Ok(dict.unbind().into())
+    }
+
+    fn get_system_config(&self) -> &str {
+        "{}"
     }
 
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -448,6 +448,10 @@ impl GlobalStateAccessor {
         "{}"
     }
 
+    fn get_next_job_id(&self) -> u32 {
+        1
+    }
+
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {
         py.eval_bound("lambda *a, **kw: []", None, None)
             .map(|value| value.unbind())

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -31,7 +31,7 @@ pub use object_ref::PyObjectRef;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
-use pyo3::types::{PyBytes, PyList, PyType};
+use pyo3::types::{PyBytes, PyDict, PyList, PyType};
 
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet")]
@@ -125,7 +125,9 @@ impl GcsClientOptions {
 
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet")]
-struct GlobalStateAccessor;
+struct GlobalStateAccessor {
+    gcs_address: String,
+}
 
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet", subclass)]
@@ -388,12 +390,42 @@ impl RawSerializedObject {
 #[pymethods]
 impl GlobalStateAccessor {
     #[new]
-    fn new(_gcs_options: Option<Py<PyAny>>) -> Self {
-        GlobalStateAccessor
+    #[pyo3(signature = (_gcs_options = None))]
+    fn new(_gcs_options: Option<&Bound<'_, PyAny>>) -> PyResult<Self> {
+        let gcs_address = match _gcs_options {
+            Some(options) => options.getattr("gcs_address")?.extract()?,
+            None => String::new(),
+        };
+        Ok(GlobalStateAccessor { gcs_address })
     }
 
     fn connect(&self) -> bool {
         true
+    }
+
+    fn get_node(&self, py: Python<'_>, node_id: &str) -> PyResult<Py<PyAny>> {
+        let client = PyGcsClient::new(self.gcs_address.clone());
+        for node in client.get_all_node_info() {
+            if hex::encode(&node.node_id) == node_id {
+                let dict = PyDict::new_bound(py);
+                dict.set_item("node_id", hex::encode(&node.node_id))?;
+                dict.set_item("node_manager_address", node.node_manager_address)?;
+                dict.set_item("raylet_socket_name", node.raylet_socket_name)?;
+                dict.set_item("object_store_socket_name", node.object_store_socket_name)?;
+                dict.set_item("node_manager_port", node.node_manager_port)?;
+                dict.set_item("object_manager_port", node.object_manager_port)?;
+                dict.set_item("metrics_export_port", node.metrics_export_port)?;
+                dict.set_item("runtime_env_agent_port", node.runtime_env_agent_port)?;
+                dict.set_item("metrics_agent_port", node.metrics_agent_port)?;
+                dict.set_item(
+                    "dashboard_agent_listen_port",
+                    node.dashboard_agent_listen_port,
+                )?;
+                dict.set_item("labels", PyDict::new_bound(py))?;
+                return Ok(dict.unbind().into());
+            }
+        }
+        Ok(py.None())
     }
 
     fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -30,6 +30,8 @@ pub use object_ref::PyObjectRef;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pyo3::types::PyType;
 
 #[cfg(feature = "python")]
 #[pyclass(module = "_raylet")]
@@ -72,6 +74,51 @@ impl DynamicObjectRefGenerator {
     #[new]
     fn new() -> Self {
         DynamicObjectRefGenerator
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct GcsClientOptions {
+    gcs_address: String,
+    cluster_id_hex: Option<String>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GcsClientOptions {
+    #[new]
+    #[pyo3(signature = (gcs_address = "", cluster_id_hex = None))]
+    fn new(gcs_address: &str, cluster_id_hex: Option<String>) -> Self {
+        GcsClientOptions {
+            gcs_address: gcs_address.to_owned(),
+            cluster_id_hex,
+        }
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (gcs_address, cluster_id_hex = None, _allow_cluster_id_nil = true, _fetch_cluster_id_if_nil = false))]
+    fn create(
+        _cls: &Bound<'_, PyType>,
+        gcs_address: &str,
+        cluster_id_hex: Option<String>,
+        _allow_cluster_id_nil: bool,
+        _fetch_cluster_id_if_nil: bool,
+    ) -> Self {
+        GcsClientOptions {
+            gcs_address: gcs_address.to_owned(),
+            cluster_id_hex,
+        }
+    }
+
+    #[getter]
+    fn gcs_address(&self) -> &str {
+        &self.gcs_address
+    }
+
+    #[getter]
+    fn cluster_id_hex(&self) -> Option<&str> {
+        self.cluster_id_hex.as_deref()
     }
 }
 
@@ -220,6 +267,7 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<core_worker::PyCoreWorker>()?;
     m.add_class::<gcs_client::PyGcsClient>()?;
     m.add_class::<cluster::PyClusterHandle>()?;
+    m.add_class::<GcsClientOptions>()?;
     m.add_class::<Config>()?;
     m.add_class::<ObjectRefGenerator>()?;
     m.add_class::<DynamicObjectRefGenerator>()?;

--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -32,6 +32,50 @@ pub use object_ref::PyObjectRef;
 use pyo3::prelude::*;
 
 #[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct Config;
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Config {
+    #[new]
+    fn new() -> Self {
+        Config
+    }
+
+    fn __getattr__(&self, py: Python<'_>, _name: &str) -> PyResult<Py<PyAny>> {
+        py.eval_bound("lambda *a, **kw: -1", None, None)
+            .map(|value| value.unbind())
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct ObjectRefGenerator;
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ObjectRefGenerator {
+    #[new]
+    fn new() -> Self {
+        ObjectRefGenerator
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyclass(module = "_raylet")]
+struct DynamicObjectRefGenerator;
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl DynamicObjectRefGenerator {
+    #[new]
+    fn new() -> Self {
+        DynamicObjectRefGenerator
+    }
+}
+
+#[cfg(feature = "python")]
 #[pyfunction]
 fn get_ray_version() -> &'static str {
     ray_common::constants::RAY_VERSION
@@ -87,6 +131,10 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ids::PyWorkerID>()?;
     m.add_class::<ids::PyNodeID>()?;
     m.add_class::<ids::PyPlacementGroupID>()?;
+    m.add_class::<ids::PyActorClassID>()?;
+    m.add_class::<ids::PyFunctionID>()?;
+    m.add_class::<ids::PyUniqueID>()?;
+    m.add_class::<ids::PyClusterID>()?;
 
     // ─── Enums ───────────────────────────────────────────────────
     m.add_class::<common::PyLanguage>()?;
@@ -97,12 +145,30 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<core_worker::PyCoreWorker>()?;
     m.add_class::<gcs_client::PyGcsClient>()?;
     m.add_class::<cluster::PyClusterHandle>()?;
+    m.add_class::<Config>()?;
+    m.add_class::<ObjectRefGenerator>()?;
+    m.add_class::<DynamicObjectRefGenerator>()?;
 
     // ─── Cluster functions ───────────────────────────────────────
     m.add_function(wrap_pyfunction!(cluster::start_cluster, m)?)?;
 
     // ─── Constants ───────────────────────────────────────────────
     m.add("RAY_VERSION", ray_common::constants::RAY_VERSION)?;
+
+    // ─── Name aliases matching the original Cython _raylet module ─
+    m.add("ObjectID", m.getattr("PyObjectID")?)?;
+    m.add("TaskID", m.getattr("PyTaskID")?)?;
+    m.add("ActorID", m.getattr("PyActorID")?)?;
+    m.add("JobID", m.getattr("PyJobID")?)?;
+    m.add("WorkerID", m.getattr("PyWorkerID")?)?;
+    m.add("NodeID", m.getattr("PyNodeID")?)?;
+    m.add("PlacementGroupID", m.getattr("PyPlacementGroupID")?)?;
+    m.add("ActorClassID", m.getattr("PyActorClassID")?)?;
+    m.add("FunctionID", m.getattr("PyFunctionID")?)?;
+    m.add("UniqueID", m.getattr("PyUniqueID")?)?;
+    m.add("ClusterID", m.getattr("PyClusterID")?)?;
+    m.add("ObjectRef", m.getattr("PyObjectRef")?)?;
+    m.add("GcsClient", m.getattr("PyGcsClient")?)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- prebuild the Rust _raylet extension in the ray-core Docker build before Bazel packaging
- serialize rustup/protoc setup in BuildKit cache mounts
- export root linker scripts needed by the Java wanda build

## Testing
- not run locally; validating with PR rust packaging preflight