### PR TITLE
ci: pull dashboard minimal failure into PR lane

### DIFF
--- a/.buildkite/fork-pipeline/core.rayci.yml
+++ b/.buildkite/fork-pipeline/core.rayci.yml
@@ -30,6 +30,28 @@ steps:
       EXTRA_DEPENDENCY: core
 
   # tests
+  - label: ":ray: core: dashboard minimal preflight"
+    tags:
+      - python
+      - dashboard
+      - min_build
+    instance_type: small
+    commands:
+      # Pull a specific failure from main build #1653 into PR CI.
+      # This should fail fast if the minimal image is missing dashboard
+      # runtime dependencies such as aiohttp.
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/dashboard:test_dashboard core
+        --python-version 3.10
+        --build-name minbuild-core-py3.10
+        --test-env=RAY_MINIMAL=1
+        --test-env=EXPECTED_PYTHON_VERSION=3.10
+        --only-tags minimal
+        --except-tags basic_test,manual,cgroup
+    depends_on:
+      - minbuild-core
+      - forge
+
+  # tests
   - label: ":ray: core: python tests"
     tags:
       - python


### PR DESCRIPTION
Pulls a specific failure from main Buildkite #1653 back into PR CI.\n\nAdds a small fork PR-lane dashboard minimal preflight that runs:\n\n```\nbazel run //ci/ray_ci:test_in_docker -- //python/ray/dashboard:test_dashboard core \\n  --python-version 3.10 \\n  --build-name minbuild-core-py3.10 \\n  --test-env=RAY_MINIMAL=1 \\n  --test-env=EXPECTED_PYTHON_VERSION=3.10 \\n  --only-tags minimal \\n  --except-tags basic_test,manual,cgroup\n```\n\nExpected initial signal: fail in PR lane if the minimal image is missing dashboard runtime deps such as aiohttp, matching the #1653 main failure surface.