### PR TITLE
ci: grant auto-merge label workflow permissions

### DIFF
--- a/.github/workflows/on_auto_merge.yaml
+++ b/.github/workflows/on_auto_merge.yaml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types:
       - auto_merge_enabled
+
+permissions:
+  issues: write
+  pull-requests: write
 jobs:
   add-go-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the pull_request_target auto-merge label workflow by granting the token issues/pull-requests write permissions. This is needed before PR #345 can use the normal auto-merge/merge-queue path, because pull_request_target executes the workflow from main.