### PR TITLE
coreworker: add current_actor_is_asyncio shim

### DIFF
--- a/rust/ray-core-worker-pylib/src/core_worker.rs
+++ b/rust/ray-core-worker-pylib/src/core_worker.rs
@@ -488,6 +488,16 @@ impl PyCoreWorker {
         false
     }
 
+    /// Cython-compatible CoreWorker.current_actor_is_asyncio() API.
+    ///
+    /// The Rust shim does not yet execute Python actor methods, so it is never
+    /// inside an asyncio actor event loop from the Python compatibility layer's
+    /// point of view. Return false to match the legacy driver/non-actor path.
+    #[pyo3(name = "current_actor_is_asyncio")]
+    fn py_current_actor_is_asyncio(&self) -> bool {
+        false
+    }
+
     /// Cython-compatible driver shutdown hook.
     ///
     /// The Rust shim does not yet own external worker resources that need an


### PR DESCRIPTION
Fixes the first post-merge main validation failure from Buildkite #1723: the minimal dashboard shard called worker.core_worker.current_actor_is_asyncio(), which the Rust PyCoreWorker compatibility layer did not expose. The shim returns false for the current driver/non-actor Rust compatibility path, matching legacy behavior outside asyncio actors.