### PR TITLE
Fix ObjectID alias for Rust _raylet

### DIFF
--- a/rust/ray-core-worker-pylib/src/lib.rs
+++ b/rust/ray-core-worker-pylib/src/lib.rs
@@ -1119,7 +1119,10 @@ fn _raylet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
 
     // ─── Name aliases matching the original Cython _raylet module ─
-    m.add("ObjectID", m.getattr("PyObjectID")?)?;
+    // In Cython Ray, ObjectID is a backwards-compatible alias for ObjectRef.
+    // Some Python paths still construct `ray.ObjectID` and pass it through
+    // APIs such as ray.get(), which validate against ray.ObjectRef.
+    m.add("ObjectID", m.getattr("PyObjectRef")?)?;
     m.add("TaskID", m.getattr("PyTaskID")?)?;
     m.add("ActorID", m.getattr("PyActorID")?)?;
     m.add("JobID", m.getattr("PyJobID")?)?;

--- a/rust/ray-core-worker-pylib/src/object_ref.rs
+++ b/rust/ray-core-worker-pylib/src/object_ref.rs
@@ -84,10 +84,38 @@ impl PyObjectRef {
         Self::new(ObjectID::from_binary(object_id_bytes), None, String::new())
     }
 
+    /// Return a nil (all-zeroes) object reference.
+    #[staticmethod]
+    #[pyo3(name = "nil")]
+    fn py_nil() -> Self {
+        Self::new(ObjectID::nil(), None, String::new())
+    }
+
+    /// Construct from a hex object ID string.
+    #[staticmethod]
+    #[pyo3(name = "from_hex")]
+    fn py_from_hex(hex_str: &str) -> Self {
+        Self::new(ObjectID::from_hex(hex_str), None, String::new())
+    }
+
+    /// Construct a random object reference.
+    #[staticmethod]
+    #[pyo3(name = "from_random")]
+    fn py_from_random() -> Self {
+        Self::new(ObjectID::from_random(), None, String::new())
+    }
+
+    /// Return the byte size of an ObjectRef/ObjectID.
+    #[staticmethod]
+    #[pyo3(name = "size")]
+    fn py_size() -> usize {
+        ObjectID::SIZE
+    }
+
     /// Return the raw bytes of the object ID.
     #[pyo3(name = "binary")]
-    fn py_binary(&self) -> Vec<u8> {
-        self.binary()
+    fn py_binary<'py>(&self, py: pyo3::Python<'py>) -> pyo3::Bound<'py, pyo3::types::PyBytes> {
+        pyo3::types::PyBytes::new_bound(py, &self.binary())
     }
 
     /// Return the hex string of the object ID.


### PR DESCRIPTION
Buildkite #1729 exposed a deterministic minimal dashboard failure where code constructed ray.ObjectID and later passed it to ray.get(), which validates against ray.ObjectRef. Cython Ray keeps ObjectID as an ObjectRef alias; the Rust _raylet module was aliasing ObjectID to PyObjectID instead.\n\nThis changes the exported ObjectID alias to PyObjectRef to match Cython compatibility.