### PR TITLE
rust: launch dashboard agent from raylet

### DIFF
--- a/rust/examples/src/actor_counter.rs
+++ b/rust/examples/src/actor_counter.rs
@@ -58,6 +58,7 @@ async fn main() {
             resources: HashMap::from([("CPU".to_string(), 4.0)]),
             labels: HashMap::new(),
             session_name: "actor-counter".to_string(),
+            dashboard_agent_command: None,
             auth_token: None,
         },
     ));

--- a/rust/examples/src/add_two_numbers.rs
+++ b/rust/examples/src/add_two_numbers.rs
@@ -57,6 +57,7 @@ async fn main() {
         resources: HashMap::from([("CPU".to_string(), 4.0)]),
         labels: HashMap::new(),
         session_name: "add-two-numbers".to_string(),
+        dashboard_agent_command: None,
         auth_token: None,
     };
     let nm = Arc::new(ray_raylet::node_manager::NodeManager::new(raylet_config));

--- a/rust/ray-conformance-tests/src/categories/multi_node.rs
+++ b/rust/ray-conformance-tests/src/categories/multi_node.rs
@@ -119,6 +119,7 @@ fn make_raylet_config(node_id: &NodeID, gcs_address: &str) -> RayletConfig {
         resources: HashMap::from([("CPU".to_string(), 4.0)]),
         labels: HashMap::new(),
         session_name: "multi-node-test".to_string(),
+        dashboard_agent_command: None,
         auth_token: None,
     }
 }

--- a/rust/ray-core-worker-pylib/src/cluster.rs
+++ b/rust/ray-core-worker-pylib/src/cluster.rs
@@ -104,6 +104,7 @@ pub fn start_cluster() -> pyo3::PyResult<PyClusterHandle> {
             resources: HashMap::from([("CPU".to_string(), 4.0)]),
             labels: HashMap::new(),
             session_name: "python-actor-demo".to_string(),
+            dashboard_agent_command: None,
             auth_token: None,
         }));
         let nm_clone = Arc::clone(&nm);

--- a/rust/ray-core-worker/tests/integration_test.rs
+++ b/rust/ray-core-worker/tests/integration_test.rs
@@ -437,6 +437,7 @@ async fn test_full_stack_gcs_raylet_worker() {
         resources: HashMap::from([("CPU".to_string(), 4.0)]),
         labels: HashMap::new(),
         session_name: "e2e-test".to_string(),
+        dashboard_agent_command: None,
         auth_token: None,
     };
     let nm = Arc::new(ray_raylet::node_manager::NodeManager::new(raylet_config));

--- a/rust/ray-raylet/src/grpc_service.rs
+++ b/rust/ray-raylet/src/grpc_service.rs
@@ -912,6 +912,7 @@ mod tests {
             ]),
             labels: std::collections::HashMap::new(),
             session_name: String::new(),
+            dashboard_agent_command: None,
             auth_token: None,
         }
     }

--- a/rust/ray-raylet/src/main.rs
+++ b/rust/ray-raylet/src/main.rs
@@ -59,6 +59,10 @@ struct Args {
     /// Session name
     #[arg(long, default_value = "")]
     session_name: String,
+
+    /// Dashboard agent command supplied by Python services.py
+    #[arg(long, alias = "dashboard_agent_command")]
+    dashboard_agent_command: Option<String>,
 }
 
 fn parse_kv_pairs(s: &str) -> HashMap<String, f64> {
@@ -118,6 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         resources,
         labels,
         session_name: args.session_name,
+        dashboard_agent_command: args.dashboard_agent_command,
         auth_token: None,
     };
 

--- a/rust/ray-raylet/src/node_manager.rs
+++ b/rust/ray-raylet/src/node_manager.rs
@@ -11,6 +11,7 @@
 //! Replaces `src/ray/raylet/node_manager.h/cc`.
 
 use std::collections::HashMap;
+use std::process::Stdio;
 use std::sync::Arc;
 
 use ray_common::config::RayConfig;
@@ -63,8 +64,38 @@ pub struct RayletConfig {
     pub resources: HashMap<String, f64>,
     pub labels: HashMap<String, String>,
     pub session_name: String,
+    /// Command line used to launch the dashboard agent subprocess. Python
+    /// passes this as a single shell-escaped string with
+    /// RAY_NODE_MANAGER_PORT_PLACEHOLDER embedded until the raylet has bound.
+    pub dashboard_agent_command: Option<String>,
     /// Cluster auth token. When set, all gRPC requests must include a matching Bearer token.
     pub auth_token: Option<String>,
+}
+
+/// Start an agent command supplied by Python's services.py.
+///
+/// The C++ raylet launches these agents as direct children so dashboard tests
+/// and fate-sharing paths can discover them under the raylet process. Keep the
+/// same parent/child shape for the Rust raylet. The command is already quoted
+/// by subprocess.list2cmdline on the Python side, so execute it through a shell
+/// after substituting the bound node-manager port.
+fn spawn_agent_command(
+    command: &str,
+    bound_port: u16,
+    process_name: &str,
+) -> std::io::Result<std::process::Child> {
+    let command = command.replace(
+        "RAY_NODE_MANAGER_PORT_PLACEHOLDER",
+        &bound_port.to_string(),
+    );
+    tracing::info!(process_name, command = %command, "Starting raylet child agent");
+    std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
 }
 
 /// The main raylet node manager.
@@ -326,6 +357,14 @@ impl NodeManager {
                 cgroup_manager,
             ));
 
+        let mut child_agents = Vec::new();
+        if let Some(command) = &self.config.dashboard_agent_command {
+            match spawn_agent_command(command, bound_port, "dashboard_agent") {
+                Ok(child) => child_agents.push(child),
+                Err(e) => tracing::warn!(error = %e, "Failed to start dashboard agent"),
+            }
+        }
+
         // Register with GCS if an address is configured.
         let gcs_state = if !self.config.gcs_address.is_empty() {
             match self.register_with_gcs(bound_port).await {
@@ -375,6 +414,13 @@ impl NodeManager {
             Self::unregister_from_gcs(gcs_client, node_id).await;
         }
 
+        for mut child in child_agents {
+            if let Err(e) = child.kill() {
+                tracing::debug!(error = %e, "Failed to kill raylet child agent");
+            }
+            let _ = child.wait();
+        }
+
         tracing::info!("Raylet shutting down");
         Ok(())
     }
@@ -399,6 +445,7 @@ mod tests {
             ]),
             labels: HashMap::from([("region".to_string(), "us-east".to_string())]),
             session_name: "test-session".to_string(),
+            dashboard_agent_command: None,
             auth_token: None,
         }
     }

--- a/rust/ray-raylet/tests/integration_test.rs
+++ b/rust/ray-raylet/tests/integration_test.rs
@@ -109,6 +109,7 @@ async fn test_raylet_registers_with_gcs() {
         resources: HashMap::from([("CPU".to_string(), 4.0)]),
         labels: HashMap::from([("env".to_string(), "test".to_string())]),
         session_name: "integration-test".to_string(),
+        dashboard_agent_command: None,
         auth_token: None,
     };
 

--- a/rust/ray-test-utils/src/lib.rs
+++ b/rust/ray-test-utils/src/lib.rs
@@ -206,6 +206,7 @@ pub async fn start_test_raylet_server() -> TestRayletServer {
         resources: HashMap::new(),
         labels: HashMap::new(),
         session_name: String::new(),
+        dashboard_agent_command: None,
         auth_token: None,
     };
 


### PR DESCRIPTION
Fixes the post-merge main dashboard failures from Buildkite #1733 by making the Rust raylet accept and launch the Python dashboard agent command as a child process after binding the node-manager port. This restores the C++ raylet parent/child shape expected by dashboard tests that search raylet_proc.children().