### PR TITLE
rust: title dashboard agent process at spawn

### DIFF
--- a/rust/ray-raylet/src/node_manager.rs
+++ b/rust/ray-raylet/src/node_manager.rs
@@ -11,6 +11,8 @@
 //! Replaces `src/ray/raylet/node_manager.h/cc`.
 
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -144,8 +146,10 @@ fn spawn_agent_command(
     );
     let argv = split_agent_command(&command)?;
     tracing::info!(process_name, argv = ?argv, "Starting raylet child agent");
-    std::process::Command::new(&argv[0])
-        .args(&argv[1..])
+    let mut cmd = std::process::Command::new(&argv[0]);
+    #[cfg(unix)]
+    cmd.arg0(process_name);
+    cmd.args(&argv[1..])
         .env("RAY_NODE_ID", node_id)
         .env("RAY_RAYLET_PID", std::process::id().to_string())
         .env("RAY_enable_pipe_based_agent_to_parent_health_check", "1")


### PR DESCRIPTION
## Summary
- start the dashboard agent with argv[0] set to ray::DashboardAgent on Unix
- keeps the agent visible to psutil cmdline checks immediately, even though the Rust _raylet setproctitle shim is process-local only

## Validation
- Not run locally: cargo is not installed in this cron environment.

Buildkite failure addressed: https://buildkite.com/netsys/ray-no-fork/builds/1754#019dfc5a-42bf-4c00-865f-44759b1e38cb