### PR TITLE
rust: use dashboard agent process title for argv0

### DIFF
--- a/rust/ray-raylet/src/node_manager.rs
+++ b/rust/ray-raylet/src/node_manager.rs
@@ -438,7 +438,7 @@ impl NodeManager {
                 .as_ref()
                 .map(|(_, node_id)| node_id.hex())
                 .unwrap_or_else(|| self.config.node_id.clone());
-            match spawn_agent_command(command, bound_port, &agent_node_id, "dashboard_agent") {
+            match spawn_agent_command(command, bound_port, &agent_node_id, "ray::DashboardAgent") {
                 Ok(child) => child_agents.push(child),
                 Err(e) => tracing::warn!(error = %e, "Failed to start dashboard agent"),
             }


### PR DESCRIPTION
Post-merge main validation #1757 still fails in //python/ray/dashboard:test_dashboard waiting for search_agent(raylet_proc.children()).\n\nPR #358 added CommandExt::arg0, but the spawn call passes `dashboard_agent` as argv[0]. The dashboard tests look for `ray::DashboardAgent` (first 15 chars), matching ray_constants.AGENT_PROCESS_TYPE_DASHBOARD_AGENT. Use that exact process title when spawning the dashboard agent from the Rust raylet.\n\nValidation: attempted `cargo fmt --check -p ray-raylet` in cron checkout; cargo is unavailable in this environment. Change is a one-token string replacement.