### PR TITLE
rust: return ObjectRef from submit_task

### DIFF
--- a/rust/ray-core-worker-pylib/src/core_worker.rs
+++ b/rust/ray-core-worker-pylib/src/core_worker.rs
@@ -925,7 +925,7 @@ impl PyCoreWorker {
         &self,
         py: pyo3::Python<'_>,
         args: &pyo3::Bound<'_, PyTuple>,
-    ) -> pyo3::PyResult<Vec<crate::ids::PyObjectID>> {
+    ) -> pyo3::PyResult<Vec<crate::object_ref::PyObjectRef>> {
         use ray_proto::ray::rpc as task_rpc;
 
         // Support both the small Rust-native compatibility form
@@ -1025,7 +1025,7 @@ impl PyCoreWorker {
 
         Ok(return_oids
             .into_iter()
-            .map(crate::ids::PyObjectID::from_inner)
+            .map(|oid| crate::object_ref::PyObjectRef::new(oid, None, String::new()))
             .collect())
     }
 }


### PR DESCRIPTION
Fix the Rust _raylet CoreWorker.submit_task compatibility path to return _raylet.ObjectRef objects instead of raw PyObjectID wrappers.

Buildkite #1763 minimal runtime-env tests failed because ray.get(f.remote()) rejected PyObjectID: object_refs must be ObjectRef or list[ObjectRef]. Returning PyObjectRef matches the Cython CoreWorker ABI expected by remote_function.py.

Validation: cargo fmt could not run in this cron environment because cargo is not installed.